### PR TITLE
Remove unecessary header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ EXTRA_CFLAGS += -fno-stack-protector
 
 all:
 	cd $(SOURCE_DIR) && $(MAKE) all;
-	tar -cf artifacts/netdata_ebpf-co-re-$(_LIBC).tar includes/*
+	tar -cf artifacts/netdata_ebpf-co-re-$(_LIBC).tar includes/*.skel.h
 	if [ "$${DEBUG:-0}" -eq 1 ]; then tar -uvf artifacts/netdata_ebpf-co-re-$(_LIBC).tar tools/check-kernel-core.sh; fi
 	xz -f artifacts/netdata_ebpf-co-re-$(_LIBC).tar
 	( cd artifacts; sha256sum netdata_ebpf-co-re-$(_LIBC).tar.xz > netdata_ebpf-co-re-$(_LIBC).tar.xz.sha256sum )


### PR DESCRIPTION
##### Summary
Last release was compressing more file than necessary, this PR is removing unnecessary headers.
##### Test Plan
1. Take a look at final tar file and verify that we only have `*.skel.h` headers.
##### Additional information

