### PR TITLE
Socket update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 *.skel.h
 *.a
 
-./src/tests/*
+src/tests/*
 ./src/*.o
 .local_libbpf/bpf
 .local_libbpf/pkgconfig

--- a/src/socket.bpf.c
+++ b/src/socket.bpf.c
@@ -474,12 +474,21 @@ int BPF_KRETPROBE(netdata_inet_csk_accept_kretprobe)
 }
 
 SEC("kretprobe/tcp_v4_connect")
-int BPF_KRETPROBE(netdata_tcp_v4_connect)
+int BPF_KRETPROBE(netdata_tcp_v4_connect_kretprobe)
 {
     int ret = (int)PT_REGS_RC(ctx);
 
     return netdata_common_tcp_connect(ret, NETDATA_KEY_CALLS_TCP_CONNECT_IPV4,
                                       NETDATA_KEY_ERROR_TCP_CONNECT_IPV4, 4);
+}
+
+SEC("kretprobe/tcp_v6_connect")
+int BPF_KRETPROBE(netdata_tcp_v6_connect_kretprobe)
+{
+    int ret = (int)PT_REGS_RC(ctx);
+
+    return netdata_common_tcp_connect(ret, NETDATA_KEY_CALLS_TCP_CONNECT_IPV6,
+                                      NETDATA_KEY_ERROR_TCP_CONNECT_IPV4, 6);
 }
 
 SEC("kprobe/tcp_retransmit_skb")
@@ -593,6 +602,20 @@ SEC("fentry/inet_csk_accept")
 int BPF_PROG(netdata_inet_csk_accept_fentry, struct sock *sk)
 {
     return netdata_common_inet_csk_accept(sk);
+}
+
+SEC("fexit/tcp_v4_connect")
+int BPF_PROG(netdata_tcp_v4_connect_fexit, struct sock *sk, struct sockaddr *uaddr, int addr_len, int ret)
+{
+    return netdata_common_tcp_connect(ret, NETDATA_KEY_CALLS_TCP_CONNECT_IPV4,
+                                      NETDATA_KEY_ERROR_TCP_CONNECT_IPV4, 4);
+}
+
+SEC("fexit/tcp_v6_connect")
+int BPF_PROG(netdata_tcp_v6_connect_fexit, struct sock *sk, struct sockaddr *uaddr, int addr_len, int ret)
+{
+    return netdata_common_tcp_connect(ret, NETDATA_KEY_CALLS_TCP_CONNECT_IPV6,
+                                      NETDATA_KEY_ERROR_TCP_CONNECT_IPV6, 6);
 }
 
 SEC("fentry/tcp_retransmit_skb")

--- a/src/socket.c
+++ b/src/socket.c
@@ -118,6 +118,17 @@ static void ebpf_disable_probes(struct socket_bpf *obj)
     bpf_program__set_autoload(obj->progs.netdata_inet_csk_accept_kretprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_tcp_v4_connect_kretprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_tcp_v6_connect_kretprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_tcp_retransmit_skb_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_tcp_retransmit_skb_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_tcp_cleanup_rbuf_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_tcp_close_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_tcp_drop_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_udp_recvmsg_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_udp_recvmsg_kretprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_tcp_sendmsg_kretprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_tcp_sendmsg_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_udp_sendmsg_kretprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_udp_sendmsg_kprobe, false);
 }
 
 static void ebpf_disable_trampoline(struct socket_bpf *obj)

--- a/src/socket.c
+++ b/src/socket.c
@@ -204,8 +204,8 @@ static inline int update_socket_tables(int fd, netdata_socket_idx_t *idx, netdat
 
 static inline int update_local_ports(struct socket_bpf *obj)
 {
-    uint16_t idx = 1;
-    uint8_t value = 1;
+    netdata_passive_connection_idx_t idx = { .protocol = 6, .port = 44444 };
+    netdata_passive_connection_t value = { .tgid = 1, .pid = 1, .counter = 1 };
     int fd = bpf_map__fd(obj->maps.tbl_lports);
     int ret = bpf_map_update_elem(fd, &idx, &value, 0);
     if (ret)
@@ -292,11 +292,11 @@ static int netdata_read_socket(netdata_socket_idx_t *idx, struct socket_bpf *obj
 
 static int netdata_read_local_ports(struct socket_bpf *obj)
 {
-    uint16_t idx = 1;
-    uint8_t value = 0;
+    netdata_passive_connection_idx_t idx = { .protocol = 6, .port = 44444 };
+    netdata_passive_connection_t value = { .tgid = 0, .pid = 0, .counter = 0 };
     int fd = bpf_map__fd(obj->maps.tbl_lports);
     if (!bpf_map_lookup_elem(fd, &idx, &value)) {
-        if (value)
+        if (value.counter)
             return 0;
     }
 


### PR DESCRIPTION
##### Summary
This PR is syncing the current CO-RE codes with PR https://github.com/netdata/kernel-collector/pull/297.

##### Test Plan

1. Clone the branch if you never did this before.
2. Initialize the submodule running `git submodule update --init --recursive`
3. Run the following command to compile the functional testes:
``` bash
# make clean; make 
```
4. Run the following tests:
```bash
# ./src/tests/socket --probe
# ./src/tests/socket --tracepoint
# ./src/tests/socket --trampoline
```

##### Additional information
This PR was already tested on the following distributions:

| Linux Distribution | kernel version | Socket log |
|--------------------|----------------|---------|
| Slackware Current  |     5.16.12    | [slackware_5_16.txt](https://github.com/netdata/ebpf-co-re/files/8219536/slackware_5_16.txt) |
| Arch Linux         |  5.16.13-arch1 | [arch_5_16.txt](https://github.com/netdata/ebpf-co-re/files/8219537/arch_5_16.txt) | 
| Ubuntu 21.04       |    5.11.0-49   | [ubuntu_5_11.txt](https://github.com/netdata/ebpf-co-re/files/8219538/ubuntu_5_11.txt) |
| Rocky Linux        | 4.18.0-348.12.2.el8_5 | [archy_4_18.txt](https://github.com/netdata/ebpf-co-re/files/8219539/archy_4_18.txt) |


