### PR TITLE
Add missing tracing

### DIFF
--- a/src/socket.bpf.c
+++ b/src/socket.bpf.c
@@ -699,6 +699,33 @@ int BPF_PROG(netdata_udp_recvmsg_fentry, struct sock *sk)
     return netdata_common_udp_recvmsg(sk);
 }
 
+SEC("fexit/udp_recvmsg")
+int BPF_PROG(netdata_udp_recvmsg_fexit, struct sock *sk, struct msghdr *msg, size_t len, int noblock,
+		int flags, int *addr_len, int ret)
+{
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+
+    libnetdata_update_global(&tbl_global_sock, NETDATA_KEY_CALLS_UDP_RECVMSG, 1);
+
+    struct sock **skpp = bpf_map_lookup_elem(&tbl_nv_udp, &pid_tgid);
+    if (skpp == 0) {
+        return 0;
+    }
+
+    struct inet_sock *is = (struct inet_sock *)(sk);
+
+    bpf_map_delete_elem(&tbl_nv_udp, &pid_tgid);
+    __u64 received = (__u64) ret;
+    update_socket_table(is, 0, received, 0, (__u16)IPPROTO_UDP);
+
+    libnetdata_update_global(&tbl_global_sock, NETDATA_KEY_BYTES_UDP_RECVMSG, received);
+
+    update_pid_table(0, received, IPPROTO_UDP);
+
+    return 0;
+}
+
 SEC("fentry/tcp_sendmsg")
 int BPF_PROG(netdata_tcp_sendmsg_fentry, struct sock *sk, struct msghdr *msg, size_t size)
 {

--- a/src/socket.bpf.c
+++ b/src/socket.bpf.c
@@ -466,14 +466,12 @@ static inline int netdata_common_udp_recvmsg_return(struct inet_sock *is, __u64 
         return 0;
     }
 
-
     bpf_map_delete_elem(&tbl_nv_udp, &pid_tgid);
     update_socket_table(is, 0, received, 0, (__u16)IPPROTO_UDP);
 
     libnetdata_update_global(&tbl_global_sock, NETDATA_KEY_BYTES_UDP_RECVMSG, received);
 
     update_pid_table(0, received, IPPROTO_UDP);
-
 
     return 0;
 }

--- a/src/socket.c
+++ b/src/socket.c
@@ -141,6 +141,7 @@ static void ebpf_disable_trampoline(struct socket_bpf *obj)
     bpf_program__set_autoload(obj->progs.netdata_tcp_cleanup_rbuf_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_tcp_close_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_udp_recvmsg_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_udp_recvmsg_fexit, false);
     bpf_program__set_autoload(obj->progs.netdata_tcp_sendmsg_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_tcp_sendmsg_fexit, false);
     bpf_program__set_autoload(obj->progs.netdata_udp_sendmsg_fentry, false);
@@ -169,6 +170,9 @@ static void ebpf_set_trampoline_target(struct socket_bpf *obj)
                                    function_list[NETDATA_FCNT_TCP_CLOSE]);
 
     bpf_program__set_attach_target(obj->progs.netdata_udp_recvmsg_fentry, 0,
+                                   function_list[NETDATA_FCNT_UDP_RECEVMSG]);
+
+    bpf_program__set_attach_target(obj->progs.netdata_udp_recvmsg_fexit, 0,
                                    function_list[NETDATA_FCNT_UDP_RECEVMSG]);
 
     bpf_program__set_attach_target(obj->progs.netdata_tcp_sendmsg_fentry, 0,


### PR DESCRIPTION
##### Summary
This PR is adding a missing trampoline to monitor UDP sockets.

##### Test Plan
1. Clone this branch
2. If this is the first time you are testing a code here, please, initialize your modules (`git submodule update --init --recursive`) before to compile
3. Compile code:
```sh
# make clean; make
```
4. Run tester with all possible arguments and compare with results at Additional information:
```sh
bash-5.1# ./src/tests/socket --probe
bash-5.1# ./src/tests/socket --trampoline
bash-5.1# ./src/tests/socket --tracepoint
```

##### Additional information

We expect to have the sentence "All stored data were retrieved with success!" for each one of the tests we run.

| Linux Distribution | kernel version | Socket log |
|--------------------|----------------|---------|
| Slackware Current  |     5.16.15    | [Slackware.txt](https://github.com/netdata/ebpf-co-re/files/8329374/Slackware.txt)  |
| Arch Linux         |  5.16.15-arch1 | [Arch.txt](https://github.com/netdata/ebpf-co-re/files/8329376/Arch.txt)  |
| Ubuntu 21.04       |    5.11.0-49   | [Ubuntu.txt](https://github.com/netdata/ebpf-co-re/files/8329377/Ubuntu.txt) |
| Manjaro 21.1       |    5.10.102-1  | [Manjaro.txt](https://github.com/netdata/ebpf-co-re/files/8329378/Manjaro.txt) | 
| Rocky 8.5          | 4.18.0-348.20.1.el8_5 | [Rocky.txt](https://github.com/netdata/ebpf-co-re/files/8329375/Rocky.txt) |

To simplify your review, we compress all reports above in an unique [file](https://github.com/netdata/ebpf-co-re/files/8329379/all.zip) . After to uncompress the data, run the following command:

```sh
bash-5.1$ grep "All stored data were retrieved with success!" *.txt | wc -l
15
```

You need to have 3 successful sentences per report.