### PR TITLE
Fix cachestat apps

### DIFF
--- a/src/cachestat.bpf.c
+++ b/src/cachestat.bpf.c
@@ -44,13 +44,10 @@ static inline int netdata_cachetat_not_update_apps(__u32 idx)
 
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
     __u32 *apps = bpf_map_lookup_elem(&cstat_ctrl ,&key);
-    if (apps) {
-        if (*apps == 0)
-            return 1;
-    } else if (!apps)
-        return 1;
+    if (apps && *apps)
+        return 0;
 
-    return 0;
+    return 1;
 }
 
 static inline int netdata_common_page_cache_lru()

--- a/src/cachestat.bpf.c
+++ b/src/cachestat.bpf.c
@@ -44,11 +44,13 @@ static inline int netdata_cachetat_not_update_apps(__u32 idx)
 
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
     __u32 *apps = bpf_map_lookup_elem(&cstat_ctrl ,&key);
-    if (apps)
+    if (apps) {
         if (*apps == 0)
-            return 0;
+            return 1;
+    } else if (!apps)
+        return 1;
 
-    return 1;
+    return 0;
 }
 
 static inline int netdata_common_page_cache_lru()

--- a/src/cachestat.c
+++ b/src/cachestat.c
@@ -196,6 +196,8 @@ static int ebpf_cachestat_tests(int selector)
         fd = bpf_map__fd(obj->maps.cstat_global);
         int fd2 = bpf_map__fd(obj->maps.cstat_pid);
         pid_t my_pid = ebpf_update_tables(fd, fd2);
+
+        sleep(10);
         ret =  ebpf_read_global_array(fd, ebpf_nprocs, NETDATA_CACHESTAT_END);
         if (!ret) {
             ret = cachestat_read_apps_array(fd2, ebpf_nprocs, (uint32_t)my_pid);


### PR DESCRIPTION
##### Summary
This PR is fixing cachestat collector that was not storing `apps` information.

##### Test Plan
1. Clone this branch
2. Compile the binaries:
```bash
# make
```
3. Run tests in one terminal and dump tables in other.
``` sh
# Terminal 1
malta2183:~/ # ./src/tests/cachestat --probe
probe: loaded with success
Global data stored with success
Apps data stored with success
malta2183:~/ # ./src/tests/cachestat --trampoline
trampoline: loaded with success
Global data stored with success
Apps data stored with success

#Terminal 2
malta2183:~/ #  bpftool map dump name cstat_pid > file.txt
```

##### Additional information

This PR was tested on:
| Linux Distribution | kernel version | Output | Probe | Trampoline |
|--------------------|----------------|---------|---------|---------|
| Slackware Current  |     5.17.2     | [slackware_5_17_out.txt](https://github.com/netdata/ebpf-co-re/files/8485583/slackware_5_17_out.txt) | [slackware_5_17_probe_dump.txt](https://github.com/netdata/ebpf-co-re/files/8485582/slackware_5_17_probe_dump.txt) | [slackware_5_17_trampoline_dump.txt](https://github.com/netdata/ebpf-co-re/files/8485581/slackware_5_17_trampoline_dump.txt) |
| Arch Linux         |  5.17.1-arch1 | [arch_5_17_out.txt](https://github.com/netdata/ebpf-co-re/files/8485597/arch_5_17_out.txt) | [arch_5_17_probe_dump.txt](https://github.com/netdata/ebpf-co-re/files/8485596/arch_5_17_probe_dump.txt) | [arch_5_17_trampoline_dump.txt](https://github.com/netdata/ebpf-co-re/files/8485595/arch_5_17_trampoline_dump.txt) |
| Ubuntu 21.04       |    5.13.0-35-generic   | [ubuntu_5_13_out.txt](https://github.com/netdata/ebpf-co-re/files/8485607/ubuntu_5_13_out.txt) | [ubuntu_5_13_probe_dump.txt](https://github.com/netdata/ebpf-co-re/files/8485608/ubuntu_5_13_probe_dump.txt) | [ubuntu_5_13_trampoline_dump.txt](https://github.com/netdata/ebpf-co-re/files/8485609/ubuntu_5_13_trampoline_dump.txt) | 
| Manjaro 21.1       |    5.10.105-1  | [manjaro_5_10_out.txt](https://github.com/netdata/ebpf-co-re/files/8485619/manjaro_5_10_out.txt) | [manjaro_5_10_probe_dump.txt](https://github.com/netdata/ebpf-co-re/files/8485620/manjaro_5_10_probe_dump.txt) | [manjaro_5_10_trampoline_dump.txt](https://github.com/netdata/ebpf-co-re/files/8485621/manjaro_5_10_trampoline_dump.txt) | 
| Alma 8.5           | 4.18.0-348.20.1.el8_5.x86_64 | [alma_4_18_out.txt](https://github.com/netdata/ebpf-co-re/files/8485645/alma_4_18_out.txt) | [alma_4_18_probe_dump.txt](https://github.com/netdata/ebpf-co-re/files/8485642/alma_4_18_probe_dump.txt) | [alma_4_18_trampoline_dump.txt](https://github.com/netdata/ebpf-co-re/files/8485650/alma_4_18_trampoline_dump.txt) |