### PR TITLE
Sync CO-RE codes with kernel-collector repo

### DIFF
--- a/Dockerfile.glibc.core
+++ b/Dockerfile.glibc.core
@@ -1,4 +1,4 @@
-FROM ubuntu:impish AS build
+FROM ubuntu:22.04 AS build
 
 ARG ARCH=x86
 ENV ARCH=$ARCH

--- a/src/cachestat.bpf.c
+++ b/src/cachestat.bpf.c
@@ -57,9 +57,8 @@ static inline int netdata_common_page_cache_lru()
     if (netdata_cachetat_not_update_apps(NETDATA_KEY_CALLS_ADD_TO_PAGE_CACHE_LRU))
         return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 key = (__u32)(pid_tgid >> 32);
-    fill = bpf_map_lookup_elem(&cstat_pid ,&key);
+    __u32 key = 0;
+    fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
     if (fill) {
         libnetdata_update_u64(&fill->add_to_page_cache_lru, 1);
     } else {
@@ -77,9 +76,8 @@ static inline int netdata_common_page_accessed()
     if (netdata_cachetat_not_update_apps(NETDATA_KEY_CALLS_MARK_PAGE_ACCESSED))
         return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 key = (__u32)(pid_tgid >> 32);
-    fill = bpf_map_lookup_elem(&cstat_pid ,&key);
+    __u32 key = 0;
+    fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
     if (fill) {
         libnetdata_update_u64(&fill->mark_page_accessed, 1);
     } else {
@@ -97,9 +95,8 @@ static inline int netdata_common_page_dirtied()
     if (netdata_cachetat_not_update_apps(NETDATA_KEY_CALLS_ACCOUNT_PAGE_DIRTIED))
         return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 key = (__u32)(pid_tgid >> 32);
-    fill = bpf_map_lookup_elem(&cstat_pid ,&key);
+    __u32 key = 0;
+    fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
     if (fill) {
         libnetdata_update_u64(&fill->account_page_dirtied, 1);
     } else {
@@ -117,14 +114,13 @@ static inline int netdata_common_buffer_dirty()
     if (netdata_cachetat_not_update_apps(NETDATA_KEY_CALLS_MARK_BUFFER_DIRTY))
         return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = (__u32)(pid_tgid >> 32);
-    fill = bpf_map_lookup_elem(&cstat_pid ,&pid);
+    __u32 key = 0;
+    fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
     if (fill) {
         libnetdata_update_u64(&fill->mark_buffer_dirty, 1);
     } else {
         data.mark_buffer_dirty = 1;
-        bpf_map_update_elem(&cstat_pid, &pid, &data, BPF_ANY);
+        bpf_map_update_elem(&cstat_pid, &key, &data, BPF_ANY);
     }
 
     return 0;

--- a/src/cachestat.c
+++ b/src/cachestat.c
@@ -156,21 +156,23 @@ static int cachestat_read_apps_array(int fd, int ebpf_nprocs, uint32_t child)
     if (!stored)
         return 2;
 
-    uint32_t my_pid = (uint32_t) getpid();
-
     uint64_t counter = 0;
-    if (!bpf_map_lookup_elem(fd, &my_pid, stored)) {
-        int j;
-        for (j = 0; j < ebpf_nprocs; j++) {
-            counter += (stored[j].add_to_page_cache_lru + stored[j].mark_page_accessed +
-                        stored[j].account_page_dirtied + stored[j].mark_buffer_dirty);
+
+    int key, next_key;
+    key = next_key = 0;
+    while (!bpf_map_get_next_key(fd, &key, &next_key)) {
+        if (!bpf_map_lookup_elem(fd, &key, stored)) {
+            counter++;
         }
+        memset(stored, 0, ebpf_nprocs*sizeof(netdata_cachestat_t));
+
+        key = next_key;
     }
 
     free(stored);
 
     if (counter) {
-        fprintf(stdout, "Apps data stored with success\n");
+        fprintf(stdout, "Apps data stored with success. It collected %lu pids\n", counter);
         return 0;
     }
 
@@ -199,7 +201,7 @@ static int ebpf_cachestat_tests(int selector, enum netdata_apps_level map_level)
         int fd2 = bpf_map__fd(obj->maps.cstat_pid);
         pid_t my_pid = ebpf_update_tables(fd, fd2);
 
-        sleep(10);
+        sleep(60);
         ret =  ebpf_read_global_array(fd, ebpf_nprocs, NETDATA_CACHESTAT_END);
         if (!ret) {
             ret = cachestat_read_apps_array(fd2, ebpf_nprocs, (uint32_t)my_pid);

--- a/src/cachestat.c
+++ b/src/cachestat.c
@@ -12,6 +12,7 @@
 
 #include <sys/stat.h>
 
+#include "netdata_defs.h"
 #include "netdata_tests.h"
 #include "netdata_cache.h"
 

--- a/src/cachestat.c
+++ b/src/cachestat.c
@@ -14,6 +14,7 @@
 
 #include "netdata_defs.h"
 #include "netdata_tests.h"
+#include "netdata_core_common.h"
 #include "netdata_cache.h"
 
 #include "cachestat.skel.h"
@@ -192,7 +193,7 @@ static int ebpf_cachestat_tests(int selector)
     int ret = ebpf_load_and_attach(obj, selector);
     if (!ret) {
         int fd = bpf_map__fd(obj->maps.cstat_ctrl);
-        update_controller_table(fd);
+        ebpf_core_fill_ctrl(obj->maps.cstat_ctrl, NETDATA_APPS_LEVEL_ALL);
 
         fd = bpf_map__fd(obj->maps.cstat_global);
         int fd2 = bpf_map__fd(obj->maps.cstat_pid);

--- a/src/dc.bpf.c
+++ b/src/dc.bpf.c
@@ -49,9 +49,7 @@ static inline int netdata_common_lookup_fast()
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    fill = bpf_map_lookup_elem(&dcstat_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &dcstat_ctrl, &dcstat_pid);
     if (fill) {
         libnetdata_update_u64(&fill->references, 1);
     } else {
@@ -73,9 +71,7 @@ static inline int netdata_common_d_lookup(long ret)
         return 0;
 
     if (*apps == 1) {
-        __u64 pid_tgid = bpf_get_current_pid_tgid();
-        key = (__u32)(pid_tgid >> 32);
-        fill = bpf_map_lookup_elem(&dcstat_pid ,&key);
+        fill = netdata_get_pid_structure(&key, &dcstat_ctrl, &dcstat_pid);
         if (fill) {
             libnetdata_update_u64(&fill->slow, 1);
         } else {
@@ -88,7 +84,7 @@ static inline int netdata_common_d_lookup(long ret)
     if (!ret) {
         libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_MISS, 1);
         if (*apps == 1) {
-            fill = bpf_map_lookup_elem(&dcstat_pid ,&key);
+            fill = netdata_get_pid_structure(&key, &dcstat_ctrl, &dcstat_pid);
             if (fill) {
                 libnetdata_update_u64(&fill->missed, 1);
             } else {

--- a/src/dc.c
+++ b/src/dc.c
@@ -179,7 +179,7 @@ int main(int argc, char **argv)
     int option_index = 0;
     enum netdata_apps_level map_level = NETDATA_APPS_LEVEL_REAL_PARENT;
     while (1) {
-        int c = getopt_long(argc, argv, "", long_options, &option_index);
+        int c = getopt_long_only(argc, argv, "", long_options, &option_index);
         if (c == -1)
             break;
 

--- a/src/dc.c
+++ b/src/dc.c
@@ -10,6 +10,7 @@
 
 #include "netdata_defs.h"
 #include "netdata_tests.h"
+#include "netdata_core_common.h"
 #include "netdata_dc.h"
 
 #include "dc.skel.h"
@@ -140,7 +141,7 @@ static int ebpf_dc_tests(int selector)
     int ret = ebpf_load_and_attach(obj, selector);
     if (!ret) {
         int fd = bpf_map__fd(obj->maps.dcstat_ctrl);
-        update_controller_table(fd);
+        ebpf_core_fill_ctrl(obj->maps.dcstat_ctrl, NETDATA_APPS_LEVEL_ALL);
 
         fd = bpf_map__fd(obj->maps.dcstat_global);
         int fd2 = bpf_map__fd(obj->maps.dcstat_pid);

--- a/src/dc.c
+++ b/src/dc.c
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "netdata_defs.h"
 #include "netdata_tests.h"
 #include "netdata_dc.h"
 

--- a/src/disk.c
+++ b/src/disk.c
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "netdata_defs.h"
 #include "netdata_tests.h"
 
 #include "disk.skel.h"

--- a/src/fd.c
+++ b/src/fd.c
@@ -10,6 +10,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "netdata_defs.h"
 #include "netdata_tests.h"
 #include "netdata_fd.h"
 

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "netdata_defs.h"
 #include "netdata_tests.h"
 #include "filesystem.skel.h"
 

--- a/src/hardirq.c
+++ b/src/hardirq.c
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "netdata_defs.h"
 #include "netdata_tests.h"
 
 #include "hardirq.skel.h"

--- a/src/mdflush.c
+++ b/src/mdflush.c
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "netdata_defs.h"
 #include "netdata_tests.h"
 
 #include "mdflush.skel.h"

--- a/src/mount.c
+++ b/src/mount.c
@@ -11,6 +11,7 @@
 #include <sys/stat.h>
 #include <sys/mount.h>
 
+#include "netdata_defs.h"
 #include "netdata_tests.h"
 #include "netdata_mount.h"
 

--- a/src/netdata_core_common.h
+++ b/src/netdata_core_common.h
@@ -9,6 +9,14 @@
 #include <bpf/libbpf.h>
 #include <bpf/btf.h>
 
+enum NETDATA_EBPF_CORE_IDX {
+    NETDATA_EBPF_CORE_IDX_HELP,
+    NETDATA_EBPF_CORE_IDX_PROBE,
+    NETDATA_EBPF_CORE_IDX_TRACEPOINT,
+    NETDATA_EBPF_CORE_IDX_TRAMPOLINE,
+    NETDATA_EBPF_CORE_IDX_PID
+};
+
 /**
  * Fill Control table
  *
@@ -28,6 +36,27 @@ static inline void ebpf_core_fill_ctrl(struct bpf_map *map, enum netdata_apps_le
          if (ret)
              fprintf(stderr, "\"error\" : \"Add key(%u) for controller table failed.\",", i);
     }
+}
+
+/**
+ * Check map level
+ *
+ * Verify if the given value is one of expected values to store inside hash table
+ *
+ * @param value is the value given
+ *
+ * @return It returns the given value when there is no error, or it returns the default when value is
+ * invalid.
+ */
+static inline enum netdata_apps_level ebpf_check_map_level(int value)
+{
+    if (value < NETDATA_APPS_LEVEL_REAL_PARENT || value > NETDATA_APPS_LEVEL_ALL) {
+        fprintf(stderr, "\"Error\" : \"Value given (%d) is not valid, resetting to default 0 (Real Parent).\",\n",
+                value);
+        value = NETDATA_APPS_LEVEL_REAL_PARENT;
+   }
+
+    return value;
 }
 
 #endif /* _NETDATA_CORE_COMMON_H_ */

--- a/src/netdata_core_common.h
+++ b/src/netdata_core_common.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef _NETDATA_CORE_COMMON_H_
+#define _NETDATA_CORE_COMMON_H_ 1
+
+#include "netdata_defs.h"
+
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
+#include <bpf/btf.h>
+
+/**
+ * Fill Control table
+ *
+ * Fill control table with data allowing eBPF collectors to store specific data.
+ *
+ * @param map the loaded map
+ * @param map_level how are we going to store PIDs
+ */
+static inline void ebpf_core_fill_ctrl(struct bpf_map *map, enum netdata_apps_level map_level)
+{
+    int fd = bpf_map__fd(map);
+
+    unsigned int i, end = bpf_map__max_entries(map);
+    uint32_t values[NETDATA_CONTROLLER_END] = { 1, map_level};
+    for (i = 0; i < end; i++) {
+         int ret = bpf_map_update_elem(fd, &i, &values[i], 0);
+         if (ret)
+             fprintf(stderr, "\"error\" : \"Add key(%u) for controller table failed.\",", i);
+    }
+}
+
+#endif /* _NETDATA_CORE_COMMON_H_ */
+

--- a/src/oomkill.c
+++ b/src/oomkill.c
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "netdata_defs.h"
 #include "netdata_tests.h"
 
 #include "oomkill.skel.h"

--- a/src/process.c
+++ b/src/process.c
@@ -11,6 +11,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "netdata_defs.h"
 #include "netdata_tests.h"
 #include "netdata_process.h"
 

--- a/src/process.c
+++ b/src/process.c
@@ -13,6 +13,7 @@
 
 #include "netdata_defs.h"
 #include "netdata_tests.h"
+#include "netdata_core_common.h"
 #include "netdata_process.h"
 
 #include "process.skel.h"
@@ -169,7 +170,7 @@ static int ebpf_process_tests(int selector)
     int ret = ebpf_load_and_attach(obj, selector);
     if (!ret) {
         int fd = bpf_map__fd(obj->maps.process_ctrl);
-        update_controller_table(fd);
+        ebpf_core_fill_ctrl(obj->maps.process_ctrl, NETDATA_APPS_LEVEL_ALL);
 
         fd = bpf_map__fd(obj->maps.tbl_total_stats);
         int fd2 = bpf_map__fd(obj->maps.tbl_pid_stats);

--- a/src/shm.c
+++ b/src/shm.c
@@ -11,6 +11,7 @@
 #include <sys/ipc.h>
 #include <sys/shm.h>
 
+#include "netdata_defs.h"
 #include "netdata_tests.h"
 #include "netdata_shm.h"
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -11,6 +11,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "netdata_defs.h"
 #include "netdata_tests.h"
 #include "netdata_socket.h"
 

--- a/src/softirq.c
+++ b/src/softirq.c
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "netdata_defs.h"
 #include "netdata_tests.h"
 
 #include "softirq.skel.h"

--- a/src/swap.c
+++ b/src/swap.c
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "netdata_defs.h"
 #include "netdata_tests.h"
 #include "netdata_swap.h"
 

--- a/src/sync.c
+++ b/src/sync.c
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "netdata_defs.h"
 #include "netdata_tests.h"
 
 #include <sys/mman.h>

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "netdata_defs.h"
 #include "netdata_tests.h"
 #include "netdata_vfs.h"
 


### PR DESCRIPTION
##### Summary
To reduce cpu and memory usage when environments have BTF available, this PR is bringing:

- Sync with kernel-collector repo
- Update of codes adding a missed header
- Modifications for `process`, `dc`, and `cachestat`, this will improve the codes allowing to monitor PIDs.
##### Test Plan
1. Clone this branch
2. Compile it : `make clean && make`
3. Go to directory `src/tests`
4. Run the following commands:
```sh
# for i in `seq 0 2`; do ./process --trampoline --pid $i ; sleep 1; done
# for i in `seq 0 2`; do ./process --probe --pid $i ; sleep 1; done
# for i in `seq 0 2`; do ./cachestat --trampoline --pid $i ; sleep 1; done
# for i in `seq 0 2`; do ./cachestat --probe --pid $i ; sleep 1; done
# for i in `seq 0 2`; do ./dc --trampoline --pid $i ; sleep 1; done
# for i in `seq 0 2`; do ./dc --probe --pid $i ; sleep 1; done
```
##### Additional information

This PR was tested on:

| Distribution | kernel |software | result | 
|-----------------|---------|------------|----------|
| Slackware current | process | 5.18.16    |  [slackware_5_18_16_process.txt](https://github.com/netdata/ebpf-co-re/files/9278701/slackware_5_18_16_process.txt) |
| Slackware current | cachestat |5.18.16    | [slackware_5_18_16_cachestat.txt](https://github.com/netdata/ebpf-co-re/files/9278702/slackware_5_18_16_cachestat.txt) |
| Slackware current | dc |5.18.16    | [slackware_5_18_16_dc.txt](https://github.com/netdata/ebpf-co-re/files/9278703/slackware_5_18_16_dc.txt) |
| Arch | process | 5.18.16-arch1 |   [arch_5_18_16_arch_process.txt](https://github.com/netdata/ebpf-co-re/files/9278710/arch_5_18_16_arch_process.txt) |
| Arch | cachestat |5.18.16-arch1 | [arch_5_18_16_arch_cachestat.txt](https://github.com/netdata/ebpf-co-re/files/9278711/arch_5_18_16_arch_cachestat.txt) |
| Arch | dc |5.18.16-arch1 |  [arch_5_18_16_arch_dc.txt](https://github.com/netdata/ebpf-co-re/files/9278712/arch_5_18_16_arch_dc.txt) |
| Ubuntu 22.04 | process |    5.15.0-33-generic   | [ubuntu_5_15_process.txt](https://github.com/netdata/ebpf-co-re/files/9283214/ubuntu_5_15_process.txt)|
| Ubuntu 22.04 | cachesstat |    5.15.0-33-generic   | [ubuntu_5_15_cachestat.txt](https://github.com/netdata/ebpf-co-re/files/9283215/ubuntu_5_15_cachestat.txt)|
| Ubuntu 22.04 | dc |    5.15.0-33-generic   | [ubuntu_5_15_dc.txt](https://github.com/netdata/ebpf-co-re/files/9283216/ubuntu_5_15_dc.txt)|
| Alma  9 | process |5.14.0-70.17.1.el9_0 | [alma_5_14_process.txt](https://github.com/netdata/ebpf-co-re/files/9278713/alma_5_14_process.txt) |
| Alma 9 | cachestat | 5.14.0-70.17.1.el9_0 | [alma_5_14_cachestat.txt](https://github.com/netdata/ebpf-co-re/files/9278714/alma_5_14_cachestat.txt) |
| Alma 9 | dc | 5.14.0-70.17.1.el9_0 |[alma_5_14_dc.txt](https://github.com/netdata/ebpf-co-re/files/9278715/alma_5_14_dc.txt) |
| Alma  8 | process |4.18.0-372.19.1.el8_6 |  [alma_4_18_process.txt](https://github.com/netdata/ebpf-co-re/files/9282353/alma_4_18_process.txt) |
| Alma 8 | cachestat | 4.18.0-372.19.1.el8_6 | [alma_4_18_cachestat.txt](https://github.com/netdata/ebpf-co-re/files/9282354/alma_4_18_cachestat.txt)|
| Alma 8 | dc | 4.18.0-372.19.1.el8_6 | [alma_4_18_dc.txt](https://github.com/netdata/ebpf-co-re/files/9282355/alma_4_18_dc.txt)|