### PR TITLE
Update 4 threads

### DIFF
--- a/src/cachestat.c
+++ b/src/cachestat.c
@@ -240,7 +240,7 @@ int main(int argc, char **argv)
 
         switch (option_index) {
             case NETDATA_EBPF_CORE_IDX_HELP: {
-                          ebpf_print_help(argv[0], "cachestat", 1);
+                          ebpf_core_print_help(argv[0], "cachestat", 1, 1);
                           exit(0);
                       }
             case NETDATA_EBPF_CORE_IDX_PROBE: {

--- a/src/cachestat.c
+++ b/src/cachestat.c
@@ -28,8 +28,11 @@ char *syscalls[] = { "add_to_page_cache_lru",
 #else
                      "account_page_dirtied",
 #endif
-                     "mark_buffer_dirty"
+                     "mark_buffer_dirty",
+                     "release_task"
 };
+// This preprocessor is defined here, because it is not useful in kernel-colector
+#define NETDATA_CACHESTAT_RELEASE_TASK 4
 
 static inline void netdata_ebpf_disable_probe(struct cachestat_bpf *obj)
 {
@@ -39,6 +42,7 @@ static inline void netdata_ebpf_disable_probe(struct cachestat_bpf *obj)
     bpf_program__set_autoload(obj->progs.netdata_set_page_dirty_kprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_account_page_dirtied_kprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_mark_buffer_dirty_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_release_task_kprobe, false);
 }
 
 static inline void netdata_ebpf_disable_specific_probe(struct cachestat_bpf *obj)
@@ -63,6 +67,7 @@ static inline void netdata_ebpf_disable_trampoline(struct cachestat_bpf *obj)
     bpf_program__set_autoload(obj->progs.netdata_set_page_dirty_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_account_page_dirtied_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_mark_buffer_dirty_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_release_task_fentry, false);
 }
 
 static inline void netdata_ebpf_disable_specific_trampoline(struct cachestat_bpf *obj)
@@ -100,6 +105,9 @@ static inline void netdata_set_trampoline_target(struct cachestat_bpf *obj)
 
     bpf_program__set_attach_target(obj->progs.netdata_mark_buffer_dirty_fentry, 0,
                                    syscalls[NETDATA_KEY_CALLS_MARK_BUFFER_DIRTY]);
+
+    bpf_program__set_attach_target(obj->progs.netdata_release_task_fentry, 0,
+                                   syscalls[NETDATA_CACHESTAT_RELEASE_TASK]);
 }
 
 static inline int ebpf_load_and_attach(struct cachestat_bpf *obj, int selector)

--- a/src/dc.c
+++ b/src/dc.c
@@ -190,7 +190,7 @@ int main(int argc, char **argv)
 
         switch (option_index) {
             case NETDATA_EBPF_CORE_IDX_HELP: {
-                          ebpf_print_help(argv[0], "dc", 1);
+                          ebpf_core_print_help(argv[0], "dc", 1, 1);
                           exit(0);
                       }
             case NETDATA_EBPF_CORE_IDX_PROBE: {

--- a/src/dc.c
+++ b/src/dc.c
@@ -16,18 +16,24 @@
 #include "dc.skel.h"
 
 char *function_list[] = { "lookup_fast",
-                          "d_lookup" };
+                          "d_lookup",
+                          "release_task"
+};
+// This preprocessor is defined here, because it is not useful in kernel-colector
+#define NETDATA_DCSTAT_RELEASE_TASK 2
 
 static inline void ebpf_disable_probes(struct dc_bpf *obj)
 {
     bpf_program__set_autoload(obj->progs.netdata_lookup_fast_kprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_d_lookup_kretprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_dcstat_release_task_kprobe, false);
 }
 
 static inline void ebpf_disable_trampoline(struct dc_bpf *obj)
 {
     bpf_program__set_autoload(obj->progs.netdata_lookup_fast_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_d_lookup_fexit, false);
+    bpf_program__set_autoload(obj->progs.netdata_dcstat_release_task_fentry, false);
 }
 
 static void ebpf_set_trampoline_target(struct dc_bpf *obj)
@@ -37,6 +43,9 @@ static void ebpf_set_trampoline_target(struct dc_bpf *obj)
 
     bpf_program__set_attach_target(obj->progs.netdata_d_lookup_fexit, 0,
                                    function_list[NETDATA_D_LOOKUP]);
+
+    bpf_program__set_attach_target(obj->progs.netdata_dcstat_release_task_fentry, 0,
+                                   function_list[NETDATA_DCSTAT_RELEASE_TASK]);
 }
 
 static int ebpf_attach_probes(struct dc_bpf *obj)
@@ -49,6 +58,13 @@ static int ebpf_attach_probes(struct dc_bpf *obj)
 
     obj->links.netdata_lookup_fast_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_lookup_fast_kprobe,
                                                                        false, function_list[NETDATA_LOOKUP_FAST]);
+    ret = libbpf_get_error(obj->links.netdata_lookup_fast_kprobe);
+    if (ret)
+        return -1;
+
+    obj->links.netdata_dcstat_release_task_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_dcstat_release_task_kprobe,
+                                                                               false,
+                                                                               function_list[NETDATA_DCSTAT_RELEASE_TASK]);
     ret = libbpf_get_error(obj->links.netdata_lookup_fast_kprobe);
     if (ret)
         return -1;

--- a/src/fd.c
+++ b/src/fd.c
@@ -20,10 +20,11 @@ char *function_list[] = { "do_sys_openat2",
 #if (MY_LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0))
                           "close_fd",
 #else
-                          "__close_fd", 
+                          "__close_fd",
 #endif
                           "release_task"
                         };
+// This preprocessor is defined here, because it is not useful in kernel-colector
 #define NETDATA_FD_RELEASE_TASK 2
 
 static inline void ebpf_disable_probes(struct fd_bpf *obj)

--- a/src/fd.c
+++ b/src/fd.c
@@ -196,7 +196,7 @@ static int fd_read_apps_array(int fd, int ebpf_nprocs, uint32_t my_pid)
     free(stored);
 
     if (counter) {
-        fprintf(stdout, "Apps data stored with success\n");
+        fprintf(stdout, "Apps data stored with success. It collected %lu pids\n", counter);
         return 0;
     }
 

--- a/src/fd.c
+++ b/src/fd.c
@@ -12,6 +12,7 @@
 
 #include "netdata_defs.h"
 #include "netdata_tests.h"
+#include "netdata_core_common.h"
 #include "netdata_fd.h"
 
 #include "fd.skel.h"
@@ -271,7 +272,7 @@ int main(int argc, char **argv)
 
         switch (c) {
             case 'h': {
-                          ebpf_print_help(argv[0], "file_descriptor", 1);
+                          ebpf_core_print_help(argv[0], "file_descriptor", 1, 1);
                           exit(0);
                       }
             case 'p': {

--- a/src/mdflush.c
+++ b/src/mdflush.c
@@ -10,6 +10,7 @@
 
 #include "netdata_defs.h"
 #include "netdata_tests.h"
+#include "netdata_core_common.h"
 
 #include "mdflush.skel.h"
 
@@ -131,7 +132,7 @@ int main(int argc, char **argv)
 
         switch (c) {
             case 'h': {
-                          ebpf_print_help(argv[0], "mdflush", 1);
+                          ebpf_core_print_help(argv[0], "mdflush", 1, 0);
                           exit(0);
                       }
             case 'p': {

--- a/src/mount.c
+++ b/src/mount.c
@@ -13,6 +13,7 @@
 
 #include "netdata_defs.h"
 #include "netdata_tests.h"
+#include "netdata_core_common.h"
 #include "netdata_mount.h"
 
 #include "mount.skel.h"
@@ -221,7 +222,7 @@ int main(int argc, char **argv)
 
         switch (c) {
             case 'h': {
-                          ebpf_print_help(argv[0], "mount", 1);
+                          ebpf_core_print_help(argv[0], "mount", 1, 0);
                           exit(0);
                       }
             case 'p': {

--- a/src/netdata_core_common.h
+++ b/src/netdata_core_common.h
@@ -59,5 +59,20 @@ static inline enum netdata_apps_level ebpf_check_map_level(int value)
     return value;
 }
 
+static inline void ebpf_core_print_help(char *name, char *info, int has_trampoline, int has_integration) {
+    fprintf(stdout, "%s tests if it is possible to monitor %s on host\n\n"
+                    "The following options are available:\n\n"
+                    "--help       : Prints this help.\n"
+                    "--probe      : Use probe and do no try to use trampolines (fentry/fexit).\n"
+                    "--tracepoint : Use tracepoint.\n"
+                    , name, info);
+    if (has_trampoline)
+        fprintf(stdout, "--trampoline : Try to use trampoline(fentry/fexit). If this is not possible"
+                        " probes will be used.\n");
+    if (has_integration)
+        fprintf(stdout, "--pid        : Store PID according argument given. Values can be:\n"
+                        "\t\t0 - Real parents\n\t\t1 - Parents\n\t\t2 - All pids\n");
+}
+
 #endif /* _NETDATA_CORE_COMMON_H_ */
 

--- a/src/netdata_core_common.h
+++ b/src/netdata_core_common.h
@@ -17,6 +17,8 @@ enum NETDATA_EBPF_CORE_IDX {
     NETDATA_EBPF_CORE_IDX_PID
 };
 
+#define NETDATA_EBPF_CORE_MIN_STORE 128
+
 /**
  * Fill Control table
  *

--- a/src/process.c
+++ b/src/process.c
@@ -109,10 +109,12 @@ static pid_t ebpf_update_tables(int global, int apps)
                                         .create_process = 1, .create_thread = 1, .task_err = 1, 
                                         .removeme = 0 };
 
-    uint32_t idx = (uint32_t)pid;
-    int ret = bpf_map_update_elem(apps, &idx, &stats, 0);
-    if (ret)
-        fprintf(stderr, "Cannot insert value to global table.");
+    uint32_t idx;
+    for (idx = 0 ; idx < 10; idx++) {
+        int ret = bpf_map_update_elem(apps, &idx, &stats, 0);
+        if (ret)
+            fprintf(stderr, "Cannot insert value to global table.");
+    }
 
     return pid;
 }

--- a/src/process.c
+++ b/src/process.c
@@ -110,7 +110,7 @@ static pid_t ebpf_update_tables(int global, int apps)
                                         .removeme = 0 };
 
     uint32_t idx;
-    for (idx = 0 ; idx < 10; idx++) {
+    for (idx = 0 ; idx < NETDATA_EBPF_CORE_MIN_STORE; idx++) {
         int ret = bpf_map_update_elem(apps, &idx, &stats, 0);
         if (ret)
             fprintf(stderr, "Cannot insert value to global table.");

--- a/src/process.c
+++ b/src/process.c
@@ -207,7 +207,7 @@ int main(int argc, char **argv)
 
         switch (option_index) {
             case NETDATA_EBPF_CORE_IDX_HELP: {
-                          ebpf_print_help(argv[0], "mount", 1);
+                          ebpf_core_print_help(argv[0], "mount", 1, 1);
                           exit(0);
                       }
             case NETDATA_EBPF_CORE_IDX_PROBE: {

--- a/src/shm.bpf.c
+++ b/src/shm.bpf.c
@@ -132,6 +132,25 @@ static inline int netdata_ebpf_common_shmctl()
     return netdata_update_apps(NETDATA_KEY_SHMCTL_CALL);
 }
 
+static inline int netdata_release_task_shm()
+{
+    netdata_shm_t *removeme;
+    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 *apps = bpf_map_lookup_elem(&shm_ctrl ,&key);
+    if (apps) {
+        if (*apps == 0)
+            return 0;
+    } else
+        return 0;
+
+    removeme = netdata_get_pid_structure(&key, &shm_ctrl, &tbl_pid_shm);
+    if (removeme) {
+        bpf_map_delete_elem(&tbl_pid_shm, &key);
+    }
+
+    return 0;
+}
+
 /************************************************************************************
  *
  *                     SHARED MEMORY (tracepoint)
@@ -192,6 +211,12 @@ int BPF_KPROBE(netdata_shmctl_probe)
     return netdata_ebpf_common_shmctl();
 }
 
+SEC("kprobe/release_task")
+int BPF_KPROBE(netdata_shm_release_task_probe)
+{
+    return netdata_release_task_shm();
+}
+
 /************************************************************************************
  *
  *                     SHARED MEMORY (trampoline)
@@ -220,6 +245,12 @@ SEC("fentry/netdata_shmctl")
 int BPF_PROG(netdata_shmctl_fentry)
 {
     return netdata_ebpf_common_shmctl();
+}
+
+SEC("fentry/release_task")
+int BPF_PROG(netdata_shm_release_task_fentry)
+{
+    return netdata_release_task_shm();
 }
 
 char _license[] SEC("license") = "GPL";

--- a/src/shm.bpf.c
+++ b/src/shm.bpf.c
@@ -68,9 +68,8 @@ static inline int netdata_update_apps(__u32 idx)
 {
     netdata_shm_t data = {};
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 key = (__u32)(pid_tgid >> 32);
-    netdata_shm_t *fill = bpf_map_lookup_elem(&tbl_pid_shm, &key);
+    __u32 key;
+    netdata_shm_t *fill = netdata_get_pid_structure(&key, &shm_ctrl, &tbl_pid_shm);
     if (fill) {
         netdata_update_stored_data(fill, idx);
     } else {

--- a/src/shm.c
+++ b/src/shm.c
@@ -194,7 +194,7 @@ void shm_fill_tables(struct shm_bpf *obj)
 
     fd = bpf_map__fd(obj->maps.tbl_pid_shm);
     netdata_shm_t apps_data = { .get = 1, .at = 1, .dt = 1, .ctl = 1};
-    for (key = 0; key < 4; key++) {
+    for (key = 0; key < 70; key++) {
         if (bpf_map_update_elem(fd, &key, &apps_data, BPF_ANY))
             fprintf(stderr, "Cannot insert key %u\n", key);
     }

--- a/src/shm.c
+++ b/src/shm.c
@@ -17,11 +17,14 @@
 
 #include "shm.skel.h"
 
-char *syscalls[NETDATA_SHM_END] = { "__x64_sys_shmget",
-                                    "__x64_sys_shmat",
-                                    "__x64_sys_shmdt",
-                                    "__x64_sys_shmctl"
+char *syscalls[] = { "__x64_sys_shmget",
+                     "__x64_sys_shmat",
+                     "__x64_sys_shmdt",
+                     "__x64_sys_shmctl",
+                     "release_task"
                                     };
+// This preprocessor is defined here, because it is not useful in kernel-colector
+#define NETDATA_SHM_RELEASE_TASK 4
 
 static void ebpf_disable_tracepoint(struct shm_bpf *obj)
 {
@@ -37,6 +40,7 @@ static void ebpf_disable_kprobe(struct shm_bpf *obj)
     bpf_program__set_autoload(obj->progs.netdata_shmat_probe, false);
     bpf_program__set_autoload(obj->progs.netdata_shmdt_probe, false);
     bpf_program__set_autoload(obj->progs.netdata_shmctl_probe, false);
+    bpf_program__set_autoload(obj->progs.netdata_shm_release_task_probe, false);
 }
 
 static void ebpf_disable_trampoline(struct shm_bpf *obj)
@@ -45,6 +49,7 @@ static void ebpf_disable_trampoline(struct shm_bpf *obj)
     bpf_program__set_autoload(obj->progs.netdata_shmat_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_shmdt_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_shmctl_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_shm_release_task_fentry, false);
 }
 
 static int ebpf_attach_kprobe(struct shm_bpf *obj)
@@ -73,6 +78,13 @@ static int ebpf_attach_kprobe(struct shm_bpf *obj)
     if (ret)
         return -1;
 
+    obj->links.netdata_shm_release_task_probe = bpf_program__attach_kprobe(obj->progs.netdata_shm_release_task_probe,
+                                                                false, syscalls[NETDATA_SHM_RELEASE_TASK]);
+    ret = libbpf_get_error(obj->links.netdata_shm_release_task_probe);
+    if (ret)
+        return -1;
+
+
     return 0;
 }
 
@@ -90,6 +102,8 @@ static void ebpf_set_trampoline_target(struct shm_bpf *obj)
     bpf_program__set_attach_target(obj->progs.netdata_shmctl_fentry, 0,
                                    syscalls[NETDATA_KEY_SHMCTL_CALL]);
 
+    bpf_program__set_attach_target(obj->progs.netdata_shm_release_task_fentry, 0,
+                                   syscalls[NETDATA_SHM_RELEASE_TASK]);
 }
 
 static inline int ebpf_load_and_attach(struct shm_bpf *obj, int selector)

--- a/src/shm.c
+++ b/src/shm.c
@@ -13,6 +13,7 @@
 
 #include "netdata_defs.h"
 #include "netdata_tests.h"
+#include "netdata_core_common.h"
 #include "netdata_shm.h"
 
 #include "shm.skel.h"
@@ -263,7 +264,7 @@ int main(int argc, char **argv)
 
         switch (c) {
             case 'h': {
-                          ebpf_print_help(argv[0], "shared_memory", 1);
+                          ebpf_core_print_help(argv[0], "shared_memory", 1, 1);
                           exit(0);
                       }
             case 'p': {

--- a/src/shm.c
+++ b/src/shm.c
@@ -194,7 +194,7 @@ void shm_fill_tables(struct shm_bpf *obj)
 
     fd = bpf_map__fd(obj->maps.tbl_pid_shm);
     netdata_shm_t apps_data = { .get = 1, .at = 1, .dt = 1, .ctl = 1};
-    for (key = 0; key < 70; key++) {
+    for (key = 0; key < NETDATA_EBPF_CORE_MIN_STORE; key++) {
         if (bpf_map_update_elem(fd, &key, &apps_data, BPF_ANY))
             fprintf(stderr, "Cannot insert key %u\n", key);
     }

--- a/src/socket.c
+++ b/src/socket.c
@@ -13,6 +13,7 @@
 
 #include "netdata_defs.h"
 #include "netdata_tests.h"
+#include "netdata_core_common.h"
 #include "netdata_socket.h"
 
 #include "socket.skel.h"
@@ -424,7 +425,7 @@ int main(int argc, char **argv)
 
         switch (c) {
             case 'h': {
-                          ebpf_print_help(argv[0], "socket", 1);
+                          ebpf_core_print_help(argv[0], "socket", 1, 1);
                           exit(0);
                       }
             case 'p': {

--- a/src/swap.bpf.c
+++ b/src/swap.bpf.c
@@ -50,9 +50,7 @@ static inline int common_readpage()
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    netdata_swap_access_t *fill = bpf_map_lookup_elem(&tbl_pid_swap ,&key);
+    netdata_swap_access_t *fill = netdata_get_pid_structure(&key, &swap_ctrl, &tbl_pid_swap);
     if (fill) {
         libnetdata_update_u64(&fill->read, 1);
     } else {
@@ -75,9 +73,7 @@ static inline int common_writepage()
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    netdata_swap_access_t *fill = bpf_map_lookup_elem(&tbl_pid_swap ,&key);
+    netdata_swap_access_t *fill = netdata_get_pid_structure(&key, &swap_ctrl, &tbl_pid_swap);
     if (fill) {
         libnetdata_update_u64(&fill->write, 1);
     } else {

--- a/src/swap.c
+++ b/src/swap.c
@@ -10,6 +10,7 @@
 
 #include "netdata_defs.h"
 #include "netdata_tests.h"
+#include "netdata_core_common.h"
 #include "netdata_swap.h"
 
 #include "swap.skel.h"
@@ -194,7 +195,7 @@ int main(int argc, char **argv)
 
         switch (c) {
             case 'h': {
-                          ebpf_print_help(argv[0], "swap", 1);
+                          ebpf_core_print_help(argv[0], "swap", 1, 1);
                           exit(0);
                       }
             case 'p': {

--- a/src/swap.c
+++ b/src/swap.c
@@ -107,7 +107,7 @@ static void ebpf_fill_tables(int global, int apps)
     netdata_swap_access_t swap_data = { .read = 1, .write = 1 };
 
     uint32_t idx;
-    for (idx = 0; idx < 10; idx++) {
+    for (idx = 0; idx < 70; idx++) {
         int ret = bpf_map_update_elem(apps, &idx, &swap_data, 0);
         if (ret)
             fprintf(stderr, "Cannot insert value to apps table.");

--- a/src/swap.c
+++ b/src/swap.c
@@ -107,7 +107,7 @@ static void ebpf_fill_tables(int global, int apps)
     netdata_swap_access_t swap_data = { .read = 1, .write = 1 };
 
     uint32_t idx;
-    for (idx = 0; idx < 70; idx++) {
+    for (idx = 0; idx < NETDATA_EBPF_CORE_MIN_STORE; idx++) {
         int ret = bpf_map_update_elem(apps, &idx, &swap_data, 0);
         if (ret)
             fprintf(stderr, "Cannot insert value to apps table.");

--- a/src/swap.c
+++ b/src/swap.c
@@ -15,18 +15,24 @@
 #include "swap.skel.h"
 
 char *function_list[] = { "swap_readpage",
-                          "swap_writepage" };
+                          "swap_writepage",
+                          "release_task"
+};
+// This preprocessor is defined here, because it is not useful in kernel-colector
+#define NETDATA_SWAP_RELEASE_TASK 2
 
 static void netdata_ebpf_disable_probe(struct swap_bpf *obj)
 {
     bpf_program__set_autoload(obj->progs.netdata_swap_readpage_probe, false);
     bpf_program__set_autoload(obj->progs.netdata_swap_writepage_probe, false);
+    bpf_program__set_autoload(obj->progs.netdata_release_task_probe, false);
 }
 
 static void netdata_ebpf_disable_trampoline(struct swap_bpf *obj)
 {
     bpf_program__set_autoload(obj->progs.netdata_swap_readpage_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_swap_writepage_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_release_task_fentry, false);
 }
 
 static void netdata_set_trampoline_target(struct swap_bpf *obj)
@@ -36,6 +42,9 @@ static void netdata_set_trampoline_target(struct swap_bpf *obj)
 
     bpf_program__set_attach_target(obj->progs.netdata_swap_writepage_fentry, 0,
                                    function_list[NETDATA_KEY_SWAP_WRITEPAGE_CALL]);
+
+    bpf_program__set_attach_target(obj->progs.netdata_release_task_fentry, 0,
+                                   function_list[NETDATA_SWAP_RELEASE_TASK]);
 }
 
 static int attach_kprobe(struct swap_bpf *obj)
@@ -49,6 +58,12 @@ static int attach_kprobe(struct swap_bpf *obj)
     obj->links.netdata_swap_writepage_probe = bpf_program__attach_kprobe(obj->progs.netdata_swap_writepage_probe,
                                                                          false, function_list[NETDATA_KEY_SWAP_WRITEPAGE_CALL]);
     ret = libbpf_get_error(obj->links.netdata_swap_writepage_probe);
+    if (ret)
+        return -1;
+
+    obj->links.netdata_release_task_probe = bpf_program__attach_kprobe(obj->progs.netdata_release_task_probe,
+                                                                       false, function_list[NETDATA_SWAP_RELEASE_TASK]);
+    ret = libbpf_get_error(obj->links.netdata_release_task_probe);
     if (ret)
         return -1;
 

--- a/src/swap.c
+++ b/src/swap.c
@@ -135,7 +135,7 @@ static int swap_read_apps_array(int fd, int ebpf_nprocs, uint32_t my_ip)
     free(stored);
 
     if (counter) {
-        fprintf(stdout, "Apps data stored with success\n");
+        fprintf(stdout, "Apps data stored with success. It collected %lu pids\n", counter);
         return 0;
     }
 
@@ -163,6 +163,7 @@ int ebpf_load_swap(int selector, enum netdata_apps_level map_level)
         fd = bpf_map__fd(obj->maps.tbl_swap);
         int fd2 = bpf_map__fd(obj->maps.tbl_pid_swap);
         pid_t my_pid = ebpf_fill_tables(fd, fd2);
+        sleep(60);
         ret =  ebpf_read_global_array(fd, ebpf_nprocs, NETDATA_SWAP_END);
         if (!ret) {
             ret =  swap_read_apps_array(fd2, ebpf_nprocs, my_pid);

--- a/src/sync.c
+++ b/src/sync.c
@@ -10,6 +10,7 @@
 
 #include "netdata_defs.h"
 #include "netdata_tests.h"
+#include "netdata_core_common.h"
 
 #include <sys/mman.h>
 
@@ -410,7 +411,7 @@ int main(int argc, char **argv)
 
         switch (c) {
             case 'h': {
-                          ebpf_print_help(argv[0], "sys_syncfs", 1);
+                          ebpf_core_print_help(argv[0], "sys_syncfs", 1, 0);
                           exit(0);
                       }
             case 'p': {

--- a/src/vfs.bpf.c
+++ b/src/vfs.bpf.c
@@ -33,6 +33,21 @@ struct {
 } vfs_ctrl SEC(".maps");
 
 /************************************************************************************
+ *
+ *                                Local Function Section
+ *
+ ***********************************************************************************/
+
+static inline void netdata_fill_common_vfs_data(struct netdata_vfs_stat_t *data)
+{
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
+
+    data->pid_tgid = pid_tgid;
+    data->pid = tgid;
+}
+
+/************************************************************************************
  *     
  *                               VFS Common
  *     
@@ -53,10 +68,7 @@ static __always_inline int netdata_common_vfs_write(__u64 tot, ssize_t ret)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->write_call, 1) ;
 
@@ -67,8 +79,7 @@ static __always_inline int netdata_common_vfs_write(__u64 tot, ssize_t ret)
             libnetdata_update_u64(&fill->write_bytes, tot);
 
     } else {
-        data.pid_tgid = pid_tgid;  
-        data.pid = tgid;  
+        netdata_fill_common_vfs_data(&data);
 
         if (ret < 0)
             data.write_err = 1;
@@ -98,10 +109,7 @@ static __always_inline int netdata_common_vfs_writev(__u64 tot, ssize_t ret)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->writev_call, 1) ;
 
@@ -112,8 +120,7 @@ static __always_inline int netdata_common_vfs_writev(__u64 tot, ssize_t ret)
             libnetdata_update_u64(&fill->writev_bytes, tot);
         }
     } else {
-        data.pid_tgid = pid_tgid;  
-        data.pid = tgid;  
+        netdata_fill_common_vfs_data(&data);
 
         if (ret < 0) {
             data.writev_err = 1;
@@ -142,10 +149,7 @@ static __always_inline int netdata_common_vfs_read(__u64 tot, ssize_t ret)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->read_call, 1) ;
 
@@ -156,8 +160,7 @@ static __always_inline int netdata_common_vfs_read(__u64 tot, ssize_t ret)
             libnetdata_update_u64(&fill->read_bytes, tot);
         }
     } else {
-        data.pid_tgid = pid_tgid;  
-        data.pid = tgid;  
+        netdata_fill_common_vfs_data(&data);
 
         if (ret < 0) {
             data.read_err = 1;
@@ -186,10 +189,7 @@ static __always_inline int netdata_common_vfs_readv(__u64 tot, ssize_t ret)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->readv_call, 1) ;
 
@@ -200,8 +200,7 @@ static __always_inline int netdata_common_vfs_readv(__u64 tot, ssize_t ret)
             libnetdata_update_u64(&fill->readv_bytes, tot);
         }
     } else {
-        data.pid_tgid = pid_tgid;  
-        data.pid = tgid;  
+        netdata_fill_common_vfs_data(&data);
 
         if (ret < 0) {
             data.readv_err = 1;
@@ -229,10 +228,7 @@ static __always_inline int netdata_common_vfs_unlink(int ret)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->unlink_call, 1) ;
 
@@ -241,8 +237,7 @@ static __always_inline int netdata_common_vfs_unlink(int ret)
             libnetdata_update_u32(&fill->unlink_err, 1) ;
         }
     } else {
-        data.pid_tgid = pid_tgid;  
-        data.pid = tgid;  
+        netdata_fill_common_vfs_data(&data);
 
         if (ret < 0)
             data.unlink_err = 1;
@@ -269,10 +264,7 @@ static __always_inline int netdata_common_vfs_fsync(int ret)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->fsync_call, 1) ;
 
@@ -281,8 +273,7 @@ static __always_inline int netdata_common_vfs_fsync(int ret)
             libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_FSYNC, 1);
         } 
     } else {
-        data.pid_tgid = pid_tgid;  
-        data.pid = tgid;  
+        netdata_fill_common_vfs_data(&data);
 
         if (ret < 0) {
             data.fsync_err = 1;
@@ -310,10 +301,7 @@ static __always_inline int netdata_common_vfs_open(int ret)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->open_call, 1) ;
 
@@ -322,8 +310,7 @@ static __always_inline int netdata_common_vfs_open(int ret)
             libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_OPEN, 1);
         } 
     } else {
-        data.pid_tgid = pid_tgid;  
-        data.pid = tgid;  
+        netdata_fill_common_vfs_data(&data);
 
         if (ret < 0) {
             data.open_err = 1;
@@ -351,10 +338,7 @@ static __always_inline int netdata_common_vfs_create(int ret)
         if (*apps == 0)
             return 0;
 
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    key = (__u32)(pid_tgid >> 32);
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-    fill = bpf_map_lookup_elem(&tbl_vfs_pid ,&key);
+    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->create_call, 1) ;
 
@@ -363,8 +347,7 @@ static __always_inline int netdata_common_vfs_create(int ret)
             libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_ERROR_VFS_CREATE, 1);
         } 
     } else {
-        data.pid_tgid = pid_tgid;  
-        data.pid = tgid;  
+        netdata_fill_common_vfs_data(&data);
 
         if (ret < 0) {
             data.create_err = 1;

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -276,23 +276,22 @@ static int vfs_read_apps_array(int fd, int ebpf_nprocs, uint32_t my_pid)
     if (!stored)
         return 2;
 
+    int key, next_key;
+    key = next_key = 0;
     uint64_t counter = 0;
-    if (!bpf_map_lookup_elem(fd, &my_pid, stored)) {
-        int j;
-        for (j = 0; j < ebpf_nprocs; j++) {
-            counter += (stored[j].pid_tgid + stored[j].pid + stored[j].write_call + stored[j].writev_call +
-                        stored[j].read_call + stored[j].readv_call + stored[j].unlink_call + stored[j].fsync_call +
-                        stored[j].open_call + stored[j].create_call + stored[j].write_bytes + stored[j].writev_bytes +
-                        stored[j].readv_bytes + stored[j].read_bytes + stored[j].write_err + stored[j].writev_err +
-                        stored[j].read_err + stored[j].readv_err + stored[j].unlink_err + stored[j].fsync_err +
-                        stored[j].fsync_err + stored[j].open_err + stored[j].create_err);
+    while (!bpf_map_get_next_key(fd, &key, &next_key)) {
+        if (!bpf_map_lookup_elem(fd, &key, stored)) {
+            counter++;
         }
+        memset(stored, 0, ebpf_nprocs * sizeof(struct netdata_vfs_stat_t));
+
+        key = next_key;
     }
 
     free(stored);
 
     if (counter) {
-        fprintf(stdout, "Apps data stored with success\n");
+        fprintf(stdout, "Apps data stored with success. It collected %lu pids\n", counter);
         return 0;
     }
 
@@ -318,7 +317,7 @@ static pid_t ebpf_update_tables(int global, int apps)
     return pid;
 }
 
-static int ebpf_vfs_tests(int selector)
+static int ebpf_vfs_tests(int selector, enum netdata_apps_level map_level)
 {
     struct vfs_bpf *obj = NULL;
     int ebpf_nprocs = (int)sysconf(_SC_NPROCESSORS_ONLN);
@@ -333,12 +332,13 @@ static int ebpf_vfs_tests(int selector)
     int ret = ebpf_load_and_attach(obj, selector);
     if (!ret) {
         int fd = bpf_map__fd(obj->maps.vfs_ctrl);
-        update_controller_table(fd);
+        ebpf_core_fill_ctrl(obj->maps.vfs_ctrl, map_level);
 
         fd = bpf_map__fd(obj->maps.tbl_vfs_stats);
         int fd2 = bpf_map__fd(obj->maps.tbl_vfs_pid);
         pid_t my_pid = ebpf_update_tables(fd, fd2);
 
+        sleep(60);
         ret =  ebpf_read_global_array(fd, ebpf_nprocs, NETDATA_VFS_COUNTER);
         if (!ret) {
             ret = vfs_read_apps_array(fd2, ebpf_nprocs, (uint32_t)my_pid);
@@ -360,36 +360,43 @@ static int ebpf_vfs_tests(int selector)
 int main(int argc, char **argv)
 {
     static struct option long_options[] = {
-        {"help",        no_argument,    0,  'h' },
-        {"probe",       no_argument,    0,  'p' },
-        {"tracepoint",  no_argument,    0,  'r' },
-        {"trampoline",  no_argument,    0,  't' },
+        {"help",        no_argument,    0,  0 },
+        {"probe",       no_argument,    0,  0 },
+        {"tracepoint",  no_argument,    0,  0 },
+        {"trampoline",  no_argument,    0,  0 },
+        {"pid",         required_argument,    0,  0 },
         {0, 0, 0, 0}
     };
 
     int selector = NETDATA_MODE_TRAMPOLINE;
     int option_index = 0;
+    enum netdata_apps_level map_level = NETDATA_APPS_LEVEL_REAL_PARENT;
     while (1) {
-        int c = getopt_long(argc, argv, "", long_options, &option_index);
+        int c = getopt_long_only(argc, argv, "", long_options, &option_index);
         if (c == -1)
             break;
 
-        switch (c) {
-            case 'h': {
+        switch (option_index) {
+            case NETDATA_EBPF_CORE_IDX_HELP: {
                           ebpf_core_print_help(argv[0], "vfs", 1, 1);
                           exit(0);
                       }
-            case 'p': {
+            case NETDATA_EBPF_CORE_IDX_PROBE: {
                           selector = NETDATA_MODE_PROBE;
                           break;
                       }
-            case 'r': {
+            case NETDATA_EBPF_CORE_IDX_TRACEPOINT: {
                           selector = NETDATA_MODE_PROBE;
                           fprintf(stdout, "This specific software does not have tracepoint, using kprobe instead\n");
                           break;
                       }
-            case 't': {
+            case NETDATA_EBPF_CORE_IDX_TRAMPOLINE: {
                           selector = NETDATA_MODE_TRAMPOLINE;
+                          break;
+                      }
+            case NETDATA_EBPF_CORE_IDX_PID: {
+                          int user_input = (int)strtol(optarg, NULL, 10);
+                          map_level = ebpf_check_map_level(user_input);
                           break;
                       }
             default: {
@@ -416,6 +423,6 @@ int main(int argc, char **argv)
         }
     }
 
-    return ebpf_vfs_tests(selector);
+    return ebpf_vfs_tests(selector, map_level);
 }
 

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -10,6 +10,7 @@
 
 #include "netdata_defs.h"
 #include "netdata_tests.h"
+#include "netdata_core_common.h"
 #include "netdata_vfs.h"
 
 #include "vfs.skel.h"
@@ -375,7 +376,7 @@ int main(int argc, char **argv)
 
         switch (c) {
             case 'h': {
-                          ebpf_print_help(argv[0], "vfs", 1);
+                          ebpf_core_print_help(argv[0], "vfs", 1, 1);
                           exit(0);
                       }
             case 'p': {


### PR DESCRIPTION
##### Summary
This PR is bringing the following changes for this repository:

- Changing PID monitoring for File Descriptor (FD), Virtual File System (VFS), Shared Memory (SHM), and swap.
- Sync code with `kernel-collector` repo
- Update help function, because old function was removed in `kernel-collector`
- Add missing `trampolines`, and `kprobe` for `cachestat` and `dc`.
- Add helpers to `netdata_core_common.h`

##### Test Plan
1. Compile this branch running:
```sh
# make clean; make
```
2. Go to `src/tests` and run the following commands:
```sh
# for i in `seq 0 2`; do ./process --trampoline --pid $i >> process.txt; done 
# for i in `seq 0 2`; do ./process --probe --pid $i >> process.txt; done 
# for i in `seq 0 2`; do ./cachestat --trampoline --pid $i >> cachestat.txt; done 
# for i in `seq 0 2`; do ./cachestat --probe --pid $i >> cachestat.txt; done 
# for i in `seq 0 2`; do ./dc --trampoline --pid $i >> dc.txt; done 
# for i in `seq 0 2`; do ./dc --probe --pid $i >> dc.txt; done 
# for i in `seq 0 2`; do ./fd --probe --pid $i >> fd.txt; done 
# for i in `seq 0 2`; do ./vfs --trampoline --pid $i >> vfs.txt; done 
# for i in `seq 0 2`; do ./vfs --probe --pid $i >> vfs.txt; done 
# for i in `seq 0 2`; do ./swap --trampoline --pid $i >> shm.txt; done 
# for i in `seq 0 2`; do ./swap --probe --pid $i >> shm.txt; done
for i in `seq 0 2`; do ./shm --trampoline --pid $i >> shm.txt; done 
for i in `seq 0 2`; do ./shm --probe --pid $i >> shm.txt; done
```
##### Additional information
This PR was tested on:

| Linux Distribution | kernel version | Process     | cachestat | dc | fd | VFS |SHM | Swap |
|-------------------------|--------------------|----------------|---------------|----|----|--------|-------|----------|
| Slackware Current  |     5.18.16    | [slackware_5_18_process.txt](https://github.com/netdata/ebpf-co-re/files/9337154/slackware_5_18_process.txt) | [slackware_5_18_cachestat.txt](https://github.com/netdata/ebpf-co-re/files/9337155/slackware_5_18_cachestat.txt) | [slackware_5_18_dc.txt](https://github.com/netdata/ebpf-co-re/files/9337156/slackware_5_18_dc.txt) | [slackware_5_18_fd.txt](https://github.com/netdata/ebpf-co-re/files/9337157/slackware_5_18_fd.txt) | [slackware_5_18_vfs.txt](https://github.com/netdata/ebpf-co-re/files/9337158/slackware_5_18_vfs.txt) | [slackware_5_18_shm.txt](https://github.com/netdata/ebpf-co-re/files/9337159/slackware_5_18_shm.txt) | [slackware_5_18_swap.txt](https://github.com/netdata/ebpf-co-re/files/9337160/slackware_5_18_swap.txt) |
| Arch Linux         |  5.18.16-arch1 | [arch_5_18_process.txt](https://github.com/netdata/ebpf-co-re/files/9337187/arch_5_18_process.txt) | [arch_5_18_cachestat.txt](https://github.com/netdata/ebpf-co-re/files/9337183/arch_5_18_cachestat.txt) | [arch_5_18_dc.txt](https://github.com/netdata/ebpf-co-re/files/9337185/arch_5_18_dc.txt) | [arch_5_18_fd.txt](https://github.com/netdata/ebpf-co-re/files/9337186/arch_5_18_fd.txt) | [arch_5_18_vfs.txt](https://github.com/netdata/ebpf-co-re/files/9337188/arch_5_18_vfs.txt) |[arch_5_18_shm.txt](https://github.com/netdata/ebpf-co-re/files/9337190/arch_5_18_shm.txt)| [arch_5_18_swap.txt](https://github.com/netdata/ebpf-co-re/files/9337191/arch_5_18_swap.txt) |
| Ubuntu 22.04       | 5.15.0-33-generic   | [ubuntu_5_15_process.txt](https://github.com/netdata/ebpf-co-re/files/9337214/ubuntu_5_15_process.txt) | [ubuntu_5_15_cachestat.txt](https://github.com/netdata/ebpf-co-re/files/9337211/ubuntu_5_15_cachestat.txt) | [ubuntu_5_15_dc.txt](https://github.com/netdata/ebpf-co-re/files/9337212/ubuntu_5_15_dc.txt) |[ubuntu_5_15_fd.txt](https://github.com/netdata/ebpf-co-re/files/9337213/ubuntu_5_15_fd.txt)| [ubuntu_5_15_vfs.txt](https://github.com/netdata/ebpf-co-re/files/9337217/ubuntu_5_15_vfs.txt) | [ubuntu_5_15_shm.txt](https://github.com/netdata/ebpf-co-re/files/9337215/ubuntu_5_15_shm.txt) | [ubuntu_5_15_swap.txt](https://github.com/netdata/ebpf-co-re/files/9337216/ubuntu_5_15_swap.txt) |
| Alma 9             | 5.14.0-70.17.1.el9_0.x86_64 |[alma_5_14_process.txt](https://github.com/netdata/ebpf-co-re/files/9337226/alma_5_14_process.txt)| [alma_5_14_cachestat.txt](https://github.com/netdata/ebpf-co-re/files/9337223/alma_5_14_cachestat.txt) | [alma_5_14_dc.txt](https://github.com/netdata/ebpf-co-re/files/9337224/alma_5_14_dc.txt) | [alma_5_14_fd.txt](https://github.com/netdata/ebpf-co-re/files/9337225/alma_5_14_fd.txt) | [alma_5_14_vfs.txt](https://github.com/netdata/ebpf-co-re/files/9337229/alma_5_14_vfs.txt) | [alma_5_14_shm.txt](https://github.com/netdata/ebpf-co-re/files/9337227/alma_5_14_shm.txt) | [alma_5_14_swap.txt](https://github.com/netdata/ebpf-co-re/files/9337228/alma_5_14_swap.txt) |
| Debian 11          | 5.10.0-16-amd64 | [debian_5_10_process.txt](https://github.com/netdata/ebpf-co-re/files/9337242/debian_5_10_process.txt) | [debian_5_10_cachestat.txt](https://github.com/netdata/ebpf-co-re/files/9337239/debian_5_10_cachestat.txt) | [debian_5_10_dc.txt](https://github.com/netdata/ebpf-co-re/files/9337240/debian_5_10_dc.txt) |[debian_5_10_fd.txt](https://github.com/netdata/ebpf-co-re/files/9337241/debian_5_10_fd.txt)| [debian_5_10_vfs.txt](https://github.com/netdata/ebpf-co-re/files/9337245/debian_5_10_vfs.txt) | [debian_5_10_shm.txt](https://github.com/netdata/ebpf-co-re/files/9337243/debian_5_10_shm.txt) | [debian_5_10_swap.txt](https://github.com/netdata/ebpf-co-re/files/9337244/debian_5_10_swap.txt) | 
| Alma 8.6           | 4.18.0-372.19.1.el8_6 | [alma_4_18_process.txt](https://github.com/netdata/ebpf-co-re/files/9337259/alma_4_18_process.txt) | [alma_4_18_cachestat.txt](https://github.com/netdata/ebpf-co-re/files/9337256/alma_4_18_cachestat.txt) |[alma_4_18_dc.txt](https://github.com/netdata/ebpf-co-re/files/9337257/alma_4_18_dc.txt)|[alma_4_18_fd.txt](https://github.com/netdata/ebpf-co-re/files/9337258/alma_4_18_fd.txt)| [alma_4_18_vfs.txt](https://github.com/netdata/ebpf-co-re/files/9337262/alma_4_18_vfs.txt)| [alma_4_18_shm.txt](https://github.com/netdata/ebpf-co-re/files/9337260/alma_4_18_shm.txt) | [alma_4_18_swap.txt](https://github.com/netdata/ebpf-co-re/files/9337261/alma_4_18_swap.txt) |

The results above were ran before last commit, so they are not showing data for some charts. When `ebpf.plugin` is running, it uses a different approach to collect PID, so it is not a concern.