### PR TITLE
Fix nv

### DIFF
--- a/src/socket.bpf.c
+++ b/src/socket.bpf.c
@@ -449,8 +449,6 @@ static inline int netdata_common_udp_recvmsg_return(struct inet_sock *is, __u64 
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
     __u64 pid_tgid = bpf_get_current_pid_tgid();
 
-    libnetdata_update_global(&tbl_global_sock, NETDATA_KEY_CALLS_UDP_RECVMSG, 1);
-
     struct sock **skpp = bpf_map_lookup_elem(&tbl_nv_udp, &pid_tgid);
     if (skpp == 0) {
         return 0;


### PR DESCRIPTION
##### Summary
Blocked by https://github.com/netdata/kernel-collector/pull/317 
##### Test Plan
1. Clone this Branch
2. Compile it:
```sh
# make clean; make
# cd src/tests/
```
3. Run software:
```sh
# for i in `seq 0 2`; do ./socket --probe --pid $i >> file.txt ; done
# for i in `seq 0 2`; do ./socket --tracepoint --pid $i >>file.txt ; done
# for i in `seq 0 2`; do ./socket --trampoline --pid $i >> file.txt ; done
```
4. The `file.txt` should not have any fail.

##### Additional information

This PR must be tested on kernel newer than `5.8`

This PR was tested on:

| Linux Distribution | kernel version | LOGS|
|----------------------------|-----------------------|---------|
|Slackware Current | 5.19.17 | [slackware_5_19.txt](https://github.com/netdata/ebpf-co-re/files/10027035/slackware_5_19.txt)|
| Arch Linux | 6.0.8-arch1-1 | [arch_6.txt](https://github.com/netdata/ebpf-co-re/files/10027038/arch_6.txt) | 
|Ubuntu 22.04 | 5.15.0-33-generic | [ubuntu_5_15.txt](https://github.com/netdata/ebpf-co-re/files/10027040/ubuntu_5_15.txt)|
| Alma 9 | 5.14.0-162.6.1.el9_1.x86_64 | [alma_5_14.txt](https://github.com/netdata/ebpf-co-re/files/10027042/alma_5_14.txt)
| Debian 11 | 5.10.0-19-amd64 | [debian_5_10.txt](https://github.com/netdata/ebpf-co-re/files/10027059/debian_5_10.txt) |
| Alma 8.6 |  4.18.0-425.3.1.el8.x86_64 | [alma_8_6.txt](https://github.com/netdata/ebpf-co-re/files/10043969/alma_8_6.txt) |