### PR TITLE
Sync eBPF code with kernel-collector

### DIFF
--- a/src/dc.bpf.c
+++ b/src/dc.bpf.c
@@ -38,7 +38,7 @@ struct {
  *
  ***********************************************************************************/
 
-static inline int netdata_common_lookup_fast()
+static __always_inline int netdata_common_lookup_fast()
 {
     netdata_dc_stat_t *fill, data = {};
     libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_REFERENCE, 1);
@@ -60,7 +60,7 @@ static inline int netdata_common_lookup_fast()
     return 0;
 }
 
-static inline int netdata_common_d_lookup(long ret)
+static __always_inline int netdata_common_d_lookup(long ret)
 {
     netdata_dc_stat_t *fill, data = {};
     libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_SLOW, 1);

--- a/src/filesystem.bpf.c
+++ b/src/filesystem.bpf.c
@@ -33,7 +33,7 @@ struct {
  *     
  ***********************************************************************************/
 
-static int netdata_fs_entry()
+static __always_inline int netdata_fs_entry()
 {
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     __u32 pid = (__u32)(pid_tgid >> 32);
@@ -44,7 +44,7 @@ static int netdata_fs_entry()
     return 0;
 }
 
-static int netdata_fs_store_bin(__u32 selection)
+static __always_inline int netdata_fs_store_bin(__u32 selection)
 {
     __u64 *fill, data;
     __u64 pid_tgid = bpf_get_current_pid_tgid();

--- a/src/mdflush.bpf.c
+++ b/src/mdflush.bpf.c
@@ -42,7 +42,7 @@ struct {
  *
  ***********************************************************************************/
 
-static int netdata_md_common(struct mddev *mddev)
+static __always_inline int netdata_md_common(struct mddev *mddev)
 {
     mdflush_key_t key = 0;
     mdflush_val_t *valp, val;

--- a/src/nfs.bpf.c
+++ b/src/nfs.bpf.c
@@ -33,7 +33,7 @@ struct {
  *     
  ***********************************************************************************/
 
-static int netdata_nfs_entry()
+static __always_inline int netdata_nfs_entry()
 {
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     __u32 pid = (__u32)(pid_tgid >> 32);
@@ -44,7 +44,7 @@ static int netdata_nfs_entry()
     return 0;
 }
 
-static int netdata_nfs_store_bin(__u32 selection)
+static __always_inline int netdata_nfs_store_bin(__u32 selection)
 {
     __u64 *fill, data;
     __u64 pid_tgid = bpf_get_current_pid_tgid();

--- a/src/process.bpf.c
+++ b/src/process.bpf.c
@@ -38,7 +38,7 @@ struct {
  *
  ***********************************************************************************/
 
-static inline void netdata_fill_common_process_data(struct netdata_pid_stat_t *data)
+static __always_inline void netdata_fill_common_process_data(struct netdata_pid_stat_t *data)
 {
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
@@ -47,7 +47,7 @@ static inline void netdata_fill_common_process_data(struct netdata_pid_stat_t *d
     data->pid = tgid;
 }
 
-static inline int netdata_common_release_task()
+static __always_inline int netdata_common_release_task()
 {
     struct netdata_pid_stat_t *fill;
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
@@ -67,7 +67,7 @@ static inline int netdata_common_release_task()
     return 0;
 }
 
-static inline int netdata_common_fork_clone(int ret)
+static __always_inline int netdata_common_fork_clone(int ret)
 {
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
     struct netdata_pid_stat_t data = { };

--- a/src/shm.bpf.c
+++ b/src/shm.bpf.c
@@ -38,7 +38,7 @@ struct {
  *
  ***********************************************************************************/
 
-static inline void netdata_update_stored_data(netdata_shm_t *data, __u32 selector)
+static __always_inline void netdata_update_stored_data(netdata_shm_t *data, __u32 selector)
 {
     // we are using if/else if instead switch to avoid warnings
     if (selector == NETDATA_KEY_SHMGET_CALL)
@@ -51,7 +51,7 @@ static inline void netdata_update_stored_data(netdata_shm_t *data, __u32 selecto
         libnetdata_update_u64(&data->ctl, 1);
 }
 
-static inline void netdata_set_structure_value(netdata_shm_t *data, __u32 selector)
+static __always_inline void netdata_set_structure_value(netdata_shm_t *data, __u32 selector)
 {
     // we are using if/else if instead switch to avoid warnings
     if (selector == NETDATA_KEY_SHMGET_CALL)
@@ -64,7 +64,7 @@ static inline void netdata_set_structure_value(netdata_shm_t *data, __u32 select
         data->ctl = 1;
 }
 
-static inline int netdata_update_apps(__u32 idx)
+static __always_inline int netdata_update_apps(__u32 idx)
 {
     netdata_shm_t data = {};
 
@@ -80,7 +80,7 @@ static inline int netdata_update_apps(__u32 idx)
     return 0;
 }
 
-static inline int netdata_global_apps_shm(__u32 idx)
+static __always_inline int netdata_global_apps_shm(__u32 idx)
 {
     libnetdata_update_global(&tbl_shm, idx, 1);
 
@@ -96,7 +96,7 @@ static inline int netdata_global_apps_shm(__u32 idx)
     return 1;
 }
 
-static inline int netdata_ebpf_common_shmget()
+static __always_inline int netdata_ebpf_common_shmget()
 {
     int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMGET_CALL);
     if (!store_apps)
@@ -105,7 +105,7 @@ static inline int netdata_ebpf_common_shmget()
     return netdata_update_apps(NETDATA_KEY_SHMGET_CALL);
 }
 
-static inline int netdata_ebpf_common_shmat()
+static __always_inline int netdata_ebpf_common_shmat()
 {
     int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMAT_CALL);
     if (!store_apps)
@@ -114,7 +114,7 @@ static inline int netdata_ebpf_common_shmat()
     return netdata_update_apps(NETDATA_KEY_SHMAT_CALL);
 }
 
-static inline int netdata_ebpf_common_shmdt()
+static __always_inline int netdata_ebpf_common_shmdt()
 {
     int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMDT_CALL);
     if (!store_apps)
@@ -123,7 +123,7 @@ static inline int netdata_ebpf_common_shmdt()
     return netdata_update_apps(NETDATA_KEY_SHMDT_CALL);
 }
 
-static inline int netdata_ebpf_common_shmctl()
+static __always_inline int netdata_ebpf_common_shmctl()
 {
     int store_apps = netdata_global_apps_shm(NETDATA_KEY_SHMCTL_CALL);
     if (!store_apps)
@@ -132,7 +132,7 @@ static inline int netdata_ebpf_common_shmctl()
     return netdata_update_apps(NETDATA_KEY_SHMCTL_CALL);
 }
 
-static inline int netdata_release_task_shm()
+static __always_inline int netdata_release_task_shm()
 {
     netdata_shm_t *removeme;
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;

--- a/src/swap.bpf.c
+++ b/src/swap.bpf.c
@@ -38,7 +38,7 @@ struct {
  *
  ***********************************************************************************/
 
-static inline int common_readpage()
+static __always_inline int common_readpage()
 {
     netdata_swap_access_t data = {};
 
@@ -61,7 +61,7 @@ static inline int common_readpage()
     return 0;
 }
 
-static inline int common_writepage()
+static __always_inline int common_writepage()
 {
     netdata_swap_access_t data = {};
 
@@ -84,7 +84,7 @@ static inline int common_writepage()
     return 0;
 }
 
-static inline int netdata_release_task_swap()
+static __always_inline int netdata_release_task_swap()
 {
     netdata_swap_access_t *removeme;
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;

--- a/src/vfs.bpf.c
+++ b/src/vfs.bpf.c
@@ -38,7 +38,7 @@ struct {
  *
  ***********************************************************************************/
 
-static inline void netdata_fill_common_vfs_data(struct netdata_vfs_stat_t *data)
+static __always_inline void netdata_fill_common_vfs_data(struct netdata_vfs_stat_t *data)
 {
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
@@ -362,7 +362,7 @@ static __always_inline int netdata_common_vfs_create(int ret)
     return 0;
 }
 
-static inline int netdata_release_task_vfs()
+static __always_inline int netdata_release_task_vfs()
 {
     struct netdata_vfs_stat_t *removeme;
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;


### PR DESCRIPTION
##### Summary
This PR is improving the current eBPF CO-RE. The original code comes from PR #32 .

##### Test Plan
The same tests described in original PR https://github.com/netdata/ebpf-co-re/pull/32.

##### Additional information
Results are also in #32 .

I retest on `Slackware current `, `Arch`, `Alma 8.6`, `Alma 9`, `Ubuntu 22.04`, and `Debian 11` the results were exactly the same, so I am not bringing nothing new here.