### PR TITLE
Add limits to socket

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,18 @@ helpful if there is no related issue.
 ##### Summary
 
 ##### Test Plan
+1. Clone this branch
+2. Run the following commands:
+```sh
+# git submodule update --init --recursive
+# make clean; make
+# cd src/tests
+# sh run_tests.sh
+```
+3. Verify that you do not have any `libbpf` error inside `error.log`.
 
 ##### Additional information
 
+| Linux Distribution |   Environment  |Kernel Version |    Error    | Success |
+|--------------------|----------------|---------------|-------------|---------|
+| LINUX DISTRIBUION  | Bare metal/VM  | uname -r      |             |         |

--- a/src/netdata_core_common.h
+++ b/src/netdata_core_common.h
@@ -121,7 +121,7 @@ static inline void ebpf_core_fill_ctrl(struct bpf_map *map, enum netdata_apps_le
  */
 static inline enum netdata_apps_level ebpf_check_map_level(int value)
 {
-    if (value < NETDATA_APPS_LEVEL_REAL_PARENT || value > NETDATA_APPS_LEVEL_ALL) {
+    if (value < NETDATA_APPS_LEVEL_REAL_PARENT || value > )NETDATA_APPS_LEVEL_IGNORE {
         fprintf(stderr, "\"Error\" : \"Value given (%d) is not valid, resetting to default 0 (Real Parent).\",\n",
                 value);
         value = NETDATA_APPS_LEVEL_REAL_PARENT;
@@ -142,7 +142,7 @@ static inline void ebpf_core_print_help(char *name, char *info, int has_trampoli
                         " probes will be used.\n");
     if (has_integration)
         fprintf(stdout, "--pid        : Store PID according argument given. Values can be:\n"
-                        "\t\t0 - Real parents\n\t\t1 - Parents\n\t\t2 - All pids\n");
+                        "\t\t0 - Real parents\n\t\t1 - Parents\n\t\t2 - All PIDs\n\t\t3 - Ignore PIDs\n");
 }
 
 /**

--- a/src/netdata_core_common.h
+++ b/src/netdata_core_common.h
@@ -121,7 +121,7 @@ static inline void ebpf_core_fill_ctrl(struct bpf_map *map, enum netdata_apps_le
  */
 static inline enum netdata_apps_level ebpf_check_map_level(int value)
 {
-    if (value < NETDATA_APPS_LEVEL_REAL_PARENT || value > )NETDATA_APPS_LEVEL_IGNORE {
+    if (value < NETDATA_APPS_LEVEL_REAL_PARENT || value > NETDATA_APPS_LEVEL_IGNORE) {
         fprintf(stderr, "\"Error\" : \"Value given (%d) is not valid, resetting to default 0 (Real Parent).\",\n",
                 value);
         value = NETDATA_APPS_LEVEL_REAL_PARENT;

--- a/src/socket.bpf.c
+++ b/src/socket.bpf.c
@@ -75,14 +75,16 @@ static __always_inline short unsigned int set_idx_value(netdata_socket_idx_t *ns
         BPF_CORE_READ_INTO(&nsi->saddr.addr32, is, sk.__sk_common.skc_rcv_saddr );
         BPF_CORE_READ_INTO(&nsi->daddr.addr32, is, sk.__sk_common.skc_daddr );
 
-        if (!nsi->saddr.addr32[0] || !nsi->daddr.addr32[0])
+        if ((nsi->saddr.addr32[0] == 0 || nsi->daddr.addr32[0] == 0) || // Zero addr
+           nsi->saddr.addr64[0] == 16777343) // Loopback
             return AF_UNSPEC;
     } else if ( family == AF_INET6 ) {
 #if defined(NETDATA_CONFIG_IPV6)
         BPF_CORE_READ_INTO(&nsi->saddr.addr8, is, sk.__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8 );
         BPF_CORE_READ_INTO(&nsi->daddr.addr8, is, sk.__sk_common.skc_v6_daddr.in6_u.u6_addr8 );
 
-        if ( ((!nsi->saddr.addr64[0]) && (!nsi->saddr.addr64[1])) || ((!nsi->daddr.addr64[0]) && (!nsi->daddr.addr64[1])))
+        if ( ((!nsi->saddr.addr64[0]) && (!nsi->saddr.addr64[1])) || ((!nsi->daddr.addr64[0]) && (!nsi->daddr.addr64[1])) || // Zero addr
+             ((nsi->saddr.addr64[0] == 0) && (nsi->saddr.addr64[1] == 72057594037927936))) // Loopback
             return AF_UNSPEC;
 #endif
     } else {
@@ -96,7 +98,12 @@ static __always_inline short unsigned int set_idx_value(netdata_socket_idx_t *ns
     nsi->dport = bpf_ntohs(nsi->dport);
     nsi->sport = bpf_ntohs(nsi->sport);
 
-    nsi->pid =  netdata_get_current_pid();
+    // Socket for nowhere or system looking for port
+    // This can be an attack vector that needs to be addressed in another opportunity
+    if (nsi->sport == 0 || nsi->dport == 0)
+        return AF_UNSPEC;
+
+    nsi->pid = netdata_get_pid(&socket_ctrl);
 
     return family;
 }

--- a/src/tests/run_tests.sh
+++ b/src/tests/run_tests.sh
@@ -51,4 +51,4 @@ done
 
 echo "We are not running filesystem or mdflush, because they can generate error, please run them."
 
-ls -lh *.log
+ls -lh ./*.log

--- a/src/tests/run_tests.sh
+++ b/src/tests/run_tests.sh
@@ -10,9 +10,9 @@ for i in "${three_tests[@]}" ; do
     {
         pid=$("./$i" --help | grep pid)
         if [ -z "${pid}" ]; then
-    	    end_loop=0
+            end_loop=0
         else
-    	    end_loop=2
+            end_loop=3
         fi
 
         for j in $(seq 0 $end_loop); do

--- a/src/tests/run_tests.sh
+++ b/src/tests/run_tests.sh
@@ -51,4 +51,4 @@ done
 
 echo "We are not running filesystem or mdflush, because they can generate error, please run them."
 
-ls -lh error.log success.log
+ls -lh *.log


### PR DESCRIPTION
##### Summary
This PR is adding another PID level that will allow users to monitor metrics independent of PID. The main goal of this PR is to create a way to summarize of socket information.
This PR also fix socket binary  that was generating unexpected result for `loopback` and zero `ports` and `addresses`.

##### Test Plan
1. Clone this branch
2. Run the following commands:
```sh
# git submodule update --init --recursive
# make clean; make
# cd src/tests
# sh run_tests.sh
```
3. Verify that you do not have any `libbpf` error inside `error.log`.
##### Additional information

| Linux Distribution | Kernel | Error | Success |  
|-----------------------------|-----------|-------------|---------|
|Slackware current | 6.1.42 |[slackware_6_1_error.txt](https://github.com/netdata/ebpf-co-re/files/12210808/slackware_6_1_error.txt) | [slackware_6_1_success.txt](https://github.com/netdata/ebpf-co-re/files/12210809/slackware_6_1_success.txt)  |
| Arch | 6.4.7-arch1-1 | [arch_6_4_error.txt](https://github.com/netdata/ebpf-co-re/files/12214774/arch_6_4_error.txt) | [arch_6_4_success.txt](https://github.com/netdata/ebpf-co-re/files/12214775/arch_6_4_success.txt) | 
| Ubuntu 22.04 | 5.15.0-76-generic | [ubuntu_5_15_error.txt](https://github.com/netdata/ebpf-co-re/files/12215503/ubuntu_5_15_error.txt) | [ubuntu_5_15_success.txt](https://github.com/netdata/ebpf-co-re/files/12215504/ubuntu_5_15_success.txt) | 
| Alma 9 | 5.14.0-284.18.1.el9_2.x86_64| [alma9_error.txt](https://github.com/netdata/ebpf-co-re/files/12215923/alma9_error.txt) | [alma9_success.txt](https://github.com/netdata/ebpf-co-re/files/12215924/alma9_success.txt) | 
| Oracle 9 | 5.14.0-284.11.1.el9_2.x86_64 | [oracle_5_14_error.txt](https://github.com/netdata/ebpf-co-re/files/12216332/oracle_5_14_error.txt) | [oracle_5_14_success.txt](https://github.com/netdata/ebpf-co-re/files/12216333/oracle_5_14_success.txt) | 
| Debian 11 | 5.10.179-3 | [debian_5_10_error.txt](https://github.com/netdata/ebpf-co-re/files/12217259/debian_5_10_error.txt) | [debian_5_10_success.txt](https://github.com/netdata/ebpf-co-re/files/12217260/debian_5_10_success.txt) | 
| Alma 8.6 | 4.18.0-477.15.1.el8_8.x86_64 | [alma8_4_18_error.txt](https://github.com/netdata/ebpf-co-re/files/12217532/alma8_4_18_error.txt) | [alma8_4_18_success.txt](https://github.com/netdata/ebpf-co-re/files/12217533/alma8_4_18_success.txt) | 