### PR TITLE
Restrict loopback  addr

### DIFF
--- a/src/socket.bpf.c
+++ b/src/socket.bpf.c
@@ -99,8 +99,8 @@ static __always_inline short unsigned int set_idx_value(netdata_socket_idx_t *ns
     BPF_CORE_READ_INTO(&nsi->dport, is, sk.__sk_common.skc_dport);
     BPF_CORE_READ_INTO(&nsi->sport, is, sk.__sk_common.skc_num);
 
-    nsi->dport = bpf_ntohs(nsi->dport);
-    nsi->sport = bpf_ntohs(nsi->sport);
+    nsi->dport = nsi->dport;
+    nsi->sport = nsi->sport;
 
     // Socket for nowhere or system looking for port
     // This can be an attack vector that needs to be addressed in another opportunity

--- a/src/socket.bpf.c
+++ b/src/socket.bpf.c
@@ -72,19 +72,23 @@ static __always_inline short unsigned int set_idx_value(netdata_socket_idx_t *ns
     BPF_CORE_READ_INTO(&family, is, sk.__sk_common.skc_family);
     // Read source and destination IPs
     if ( family == AF_INET ) { //AF_INET
-        BPF_CORE_READ_INTO(&nsi->saddr.addr32, is, sk.__sk_common.skc_rcv_saddr );
-        BPF_CORE_READ_INTO(&nsi->daddr.addr32, is, sk.__sk_common.skc_daddr );
+        BPF_CORE_READ_INTO(&nsi->saddr.addr32[0], is, sk.__sk_common.skc_rcv_saddr );
+        BPF_CORE_READ_INTO(&nsi->daddr.addr32[0], is, sk.__sk_common.skc_daddr );
 
         if ((nsi->saddr.addr32[0] == 0 || nsi->daddr.addr32[0] == 0) || // Zero addr
-           nsi->saddr.addr64[0] == 16777343) // Loopback
+           nsi->saddr.addr32[0] == 16777343 || nsi->daddr.addr32[0] == 16777343) // Loopback
             return AF_UNSPEC;
     } else if ( family == AF_INET6 ) {
 #if defined(NETDATA_CONFIG_IPV6)
         BPF_CORE_READ_INTO(&nsi->saddr.addr8, is, sk.__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8 );
         BPF_CORE_READ_INTO(&nsi->daddr.addr8, is, sk.__sk_common.skc_v6_daddr.in6_u.u6_addr8 );
 
-        if ( ((!nsi->saddr.addr64[0]) && (!nsi->saddr.addr64[1])) || ((!nsi->daddr.addr64[0]) && (!nsi->daddr.addr64[1])) || // Zero addr
-             ((nsi->saddr.addr64[0] == 0) && (nsi->saddr.addr64[1] == 72057594037927936))) // Loopback
+        if (((nsi->saddr.addr64[0] == 0) && (nsi->saddr.addr64[1] == 72057594037927936)) ||  // Loopback
+            ((nsi->daddr.addr64[0] == 0) && (nsi->daddr.addr64[1] == 72057594037927936)))
+            return AF_UNSPEC;
+
+        if (((nsi->saddr.addr64[0] == 0) && (nsi->saddr.addr64[1] == 0)) ||
+            ((nsi->daddr.addr64[0] == 0) && (nsi->daddr.addr64[1] == 0))) // Zero addr
             return AF_UNSPEC;
 #endif
     } else {


### PR DESCRIPTION
##### Summary
Sync current repo with kernel-collector repo.

##### Test Plan
1. Clone this branch
2. Run the following commands:
```sh
# git submodule update --init --recursive
# make clean; make
# cd src/tests
# sh run_tests.sh
```
3. Verify that you do not have any `libbpf` error inside `error.log`.

##### Additional information

| Linux Distribution |   Environment  |Kernel Version |    Error    | Success |
|--------------------|----------------|---------------|-------------|---------|
| Slackare Current  | Bare metal  | 6.1.43      | [slackware_6_1_error.txt](https://github.com/netdata/ebpf-co-re/files/12326152/slackware_6_1_error.txt) | [slackware_6_1_success.txt](https://github.com/netdata/ebpf-co-re/files/12326153/slackware_6_1_success.txt)|
| Arch Linux | Libvirt | 6.4.10-arch1-1 | [arch_6_4_error.txt](https://github.com/netdata/ebpf-co-re/files/12330818/arch_6_4_error.txt) | [arch_6_4_success.txt](https://github.com/netdata/ebpf-co-re/files/12330819/arch_6_4_success.txt) | 
| Ubuntu 22.04 | Libvirt | 5.15.0-76-generic | [ubuntu_5_15_error.txt](https://github.com/netdata/ebpf-co-re/files/12330892/ubuntu_5_15_error.txt) | [ubuntu_5_15_success.txt](https://github.com/netdata/ebpf-co-re/files/12330893/ubuntu_5_15_success.txt) |
|Alma 9 | libvirt | 5.14.0-284.25.1.el9_2.x86_64 | [alma9_5_14_error.log](https://github.com/netdata/ebpf-co-re/files/12335584/alma9_5_14_error.log) | [alma9_5_14_success.log](https://github.com/netdata/ebpf-co-re/files/12335589/alma9_5_14_success.log) | 
| Debian 11  | libvirt | 5.10.0-23-amd64 | [debian_5_10_error.txt](https://github.com/netdata/ebpf-co-re/files/12334610/debian_5_10_error.txt) | [debian_5_10_success.txt](https://github.com/netdata/ebpf-co-re/files/12334612/debian_5_10_success.txt) | 
| Alma 8.6 | libvirt | 4.18.0-477.15.1.el8_8.x86_64 | [alma_4_18_error.txt](https://github.com/netdata/ebpf-co-re/files/12331170/alma_4_18_error.txt) | [alma_4_18_success.txt](https://github.com/netdata/ebpf-co-re/files/12331171/alma_4_18_success.txt) | 