### PR TITLE
Network Viewer basis

### DIFF
--- a/src/socket.bpf.c
+++ b/src/socket.bpf.c
@@ -72,7 +72,8 @@ static __always_inline short unsigned int set_idx_value(netdata_socket_idx_t *ns
     BPF_CORE_READ_INTO(&family, is, sk.__sk_common.skc_family);
     // Read source and destination IPs
     if ( family == AF_INET ) { //AF_INET
-        BPF_CORE_READ_INTO(&nsi->saddr.addr32[0], is, sk.__sk_common.skc_rcv_saddr );
+        //BPF_CORE_READ_INTO(&nsi->saddr.addr32[0], is, sk.__sk_common.skc_rcv_saddr ); //bind to local address
+        BPF_CORE_READ_INTO(&nsi->saddr.addr32[0], is, inet_saddr );
         BPF_CORE_READ_INTO(&nsi->daddr.addr32[0], is, sk.__sk_common.skc_daddr );
 
         if ((nsi->saddr.addr32[0] == 0 || nsi->daddr.addr32[0] == 0) || // Zero addr

--- a/src/socket.bpf.c
+++ b/src/socket.bpf.c
@@ -279,7 +279,7 @@ static __always_inline int netdata_common_inet_csk_accept(struct sock *sk)
         libnetdata_update_global(&socket_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
     }
 
-    struct inet_sock *is = inet_sk(sk);
+    struct inet_sock *is = (struct inet_sock *)sk;
     netdata_socket_idx_t nv_idx = { };
     __u16 family = set_idx_value(&nv_idx, is);
     if (family == AF_UNSPEC)

--- a/src/socket.bpf.c
+++ b/src/socket.bpf.c
@@ -279,6 +279,28 @@ static __always_inline int netdata_common_inet_csk_accept(struct sock *sk)
         libnetdata_update_global(&socket_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
     }
 
+    struct inet_sock *is = inet_sk(sk);
+    netdata_socket_idx_t nv_idx = { };
+    __u16 family = set_idx_value(&nv_idx, is);
+    if (family == AF_UNSPEC)
+        return 0;
+
+    netdata_socket_t *val;
+    netdata_socket_t nv_data = { };
+
+    val = (netdata_socket_t *) bpf_map_lookup_elem(&tbl_nd_socket, &nv_idx);
+    if (val) {
+        libnetdata_update_u32(&val->external_origin, 1);
+    } else {
+        nv_data.first = bpf_ktime_get_ns();
+        nv_data.ct = nv_data.first;
+        nv_data.protocol = protocol;
+        nv_data.family = family;
+        nv_data.external_origin = 1;
+
+        bpf_map_update_elem(&tbl_nd_socket, &nv_idx, &nv_data, BPF_ANY);
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
##### Summary
Sync branches and update socket algorithm to bring basis for our network viewer.

##### Test Plan
1. Clone this branch
2. Run the following commands:
```sh
# git submodule update --init --recursive
# make clean; make
# cd src/tests
# sh run_tests.sh
```
3. Verify that you do not have any `libbpf` error inside `error.log`.

##### Additional information

| Linux Distribution |   Environment  |Kernel Version |    Error    | Success |
|--------------------|----------------|---------------|-------------|---------|
| Slackware currentt  | Bare metal  | 6.1.51  |[slackware_6_1_error.log](https://github.com/netdata/ebpf-co-re/files/12517745/slackware_6_1_error.log) | [slackware_6_1_success.log](https://github.com/netdata/ebpf-co-re/files/12517746/slackware_6_1_success.log) |
|Debian 11 | Libvirt | 5.10.191-1 | [debian_11_error.log](https://github.com/netdata/ebpf-co-re/files/12518148/debian_11_error.log) | [debian_11_success.log](https://github.com/netdata/ebpf-co-re/files/12518149/debian_11_success.log) | 
