### PR TITLE
Modify destination fixing issues with CO-RE

### DIFF
--- a/src/socket.bpf.c
+++ b/src/socket.bpf.c
@@ -409,6 +409,14 @@ int BPF_KRETPROBE(netdata_inet_csk_accept_kretprobe)
     return netdata_common_inet_csk_accept(sk);
 }
 
+SEC("kprobe/tcp_v4_connect")
+int BPF_KRETPROBE(netdata_tcp_v4_connect_kprobe)
+{
+    struct inet_sock *is = (struct inet_sock *)((struct sock *)PT_REGS_PARM1(ctx));
+    return netdata_common_tcp_connect(is, 0, NETDATA_KEY_CALLS_TCP_CONNECT_IPV4,
+                                      NETDATA_KEY_ERROR_TCP_CONNECT_IPV4);
+}
+
 SEC("kretprobe/tcp_v4_connect")
 int BPF_KRETPROBE(netdata_tcp_v4_connect_kretprobe)
 {
@@ -419,6 +427,14 @@ int BPF_KRETPROBE(netdata_tcp_v4_connect_kretprobe)
                                       NETDATA_KEY_ERROR_TCP_CONNECT_IPV4);
 }
 
+SEC("kprobe/tcp_v6_connect")
+int BPF_KRETPROBE(netdata_tcp_v6_connect_kprobe)
+{
+    struct inet_sock *is = (struct inet_sock *)((struct sock *)PT_REGS_PARM1(ctx));
+    return netdata_common_tcp_connect(is, 0, NETDATA_KEY_CALLS_TCP_CONNECT_IPV6,
+                                      NETDATA_KEY_ERROR_TCP_CONNECT_IPV6);
+}
+
 SEC("kretprobe/tcp_v6_connect")
 int BPF_KRETPROBE(netdata_tcp_v6_connect_kretprobe)
 {
@@ -426,7 +442,7 @@ int BPF_KRETPROBE(netdata_tcp_v6_connect_kretprobe)
 
     struct inet_sock *is = (struct inet_sock *)((struct sock *)PT_REGS_PARM1(ctx));
     return netdata_common_tcp_connect(is, ret, NETDATA_KEY_CALLS_TCP_CONNECT_IPV6,
-                                      NETDATA_KEY_ERROR_TCP_CONNECT_IPV4);
+                                      NETDATA_KEY_ERROR_TCP_CONNECT_IPV6);
 }
 
 SEC("kprobe/tcp_retransmit_skb")
@@ -528,6 +544,17 @@ int BPF_PROG(netdata_inet_csk_accept_fexit, struct sock *sk)
     return netdata_common_inet_csk_accept(sk);
 }
 
+SEC("fentry/tcp_v4_connect")
+int BPF_PROG(netdata_tcp_v4_connect_fentry, struct sock *sk, struct sockaddr *uaddr, int addr_len, int ret)
+{
+    if (!sk)
+        return 0;
+
+    struct inet_sock *is = (struct inet_sock *)sk;
+    return netdata_common_tcp_connect(is, 0, NETDATA_KEY_CALLS_TCP_CONNECT_IPV4,
+                                      NETDATA_KEY_ERROR_TCP_CONNECT_IPV4);
+}
+
 SEC("fexit/tcp_v4_connect")
 int BPF_PROG(netdata_tcp_v4_connect_fexit, struct sock *sk, struct sockaddr *uaddr, int addr_len, int ret)
 {
@@ -537,6 +564,17 @@ int BPF_PROG(netdata_tcp_v4_connect_fexit, struct sock *sk, struct sockaddr *uad
     struct inet_sock *is = (struct inet_sock *)sk;
     return netdata_common_tcp_connect(is, ret, NETDATA_KEY_CALLS_TCP_CONNECT_IPV4,
                                       NETDATA_KEY_ERROR_TCP_CONNECT_IPV4);
+}
+
+SEC("fentry/tcp_v6_connect")
+int BPF_PROG(netdata_tcp_v6_connect_fentry, struct sock *sk, struct sockaddr *uaddr, int addr_len, int ret)
+{
+    if (!sk)
+        return 0;
+
+    struct inet_sock *is = (struct inet_sock *)sk;
+    return netdata_common_tcp_connect(is, 0, NETDATA_KEY_CALLS_TCP_CONNECT_IPV6,
+                                      NETDATA_KEY_ERROR_TCP_CONNECT_IPV6);
 }
 
 SEC("fexit/tcp_v6_connect")

--- a/src/socket.bpf.c
+++ b/src/socket.bpf.c
@@ -519,8 +519,8 @@ int BPF_KPROBE(netdata_udp_sendmsg_kprobe)
  *
  ***********************************************************************************/
 
-SEC("fentry/inet_csk_accept")
-int BPF_PROG(netdata_inet_csk_accept_fentry, struct sock *sk)
+SEC("fexit/inet_csk_accept")
+int BPF_PROG(netdata_inet_csk_accept_fexit, struct sock *sk)
 {
     if (!sk)
         return 0;

--- a/src/socket.c
+++ b/src/socket.c
@@ -127,7 +127,7 @@ static void ebpf_disable_probes(struct socket_bpf *obj)
 
 static void ebpf_disable_trampoline(struct socket_bpf *obj)
 {
-    bpf_program__set_autoload(obj->progs.netdata_inet_csk_accept_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_inet_csk_accept_fexit, false);
     bpf_program__set_autoload(obj->progs.netdata_tcp_v4_connect_fexit, false);
     bpf_program__set_autoload(obj->progs.netdata_tcp_v6_connect_fexit, false);
     bpf_program__set_autoload(obj->progs.netdata_tcp_retransmit_skb_fentry, false);
@@ -143,7 +143,7 @@ static void ebpf_disable_trampoline(struct socket_bpf *obj)
 
 static void ebpf_set_trampoline_target(struct socket_bpf *obj)
 {
-    bpf_program__set_attach_target(obj->progs.netdata_inet_csk_accept_fentry, 0,
+    bpf_program__set_attach_target(obj->progs.netdata_inet_csk_accept_fexit, 0,
                                    function_list[NETDATA_FCNT_INET_CSK_ACCEPT]);
 
     bpf_program__set_attach_target(obj->progs.netdata_tcp_v4_connect_fexit, 0,


### PR DESCRIPTION
##### Summary
When `ebpf.plugin` were classifying the socket origin, it was not able to classify correctly the passive connections, because we were attaching a `trampoline` to `fentry` instead `fexit`. This PR addresses this issue that are not happening in `kernel-collector` repo.

##### Test Plan
1. Clone this branch
2. Run the following commands:
```sh
# git submodule update --init --recursive
# make clean; make
# cd src/tests
# sh run_tests.sh
```
3. Verify that you do not have any `libbpf` error inside `error.log`.

##### Additional information

| Linux Distribution |   Environment  |Kernel Version |    Error    | Success |
|--------------------|----------------|---------------|-------------|---------|
| Slackware current  | Bare metal  | 6.1.51      | [slackware_6_1_error.txt](https://github.com/netdata/ebpf-co-re/files/12539446/slackware_6_1_error.txt) | [slackware_6_1_success.txt](https://github.com/netdata/ebpf-co-re/files/12539447/slackware_6_1_success.txt) |