### PR TITLE
VFS functions

### DIFF
--- a/src/netdata_core_common.h
+++ b/src/netdata_core_common.h
@@ -9,6 +9,10 @@
 #include <bpf/libbpf.h>
 #include <bpf/btf.h>
 
+#ifndef TASK_COMM_LEN
+#define TASK_COMM_LEN 16
+#endif
+
 enum NETDATA_EBPF_CORE_IDX {
     NETDATA_EBPF_CORE_IDX_HELP,
     NETDATA_EBPF_CORE_IDX_PROBE,

--- a/src/vfs.bpf.c
+++ b/src/vfs.bpf.c
@@ -40,11 +40,8 @@ struct {
 
 static __always_inline void netdata_fill_common_vfs_data(struct netdata_vfs_stat_t *data)
 {
-    __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
-
-    data->pid_tgid = pid_tgid;
-    data->pid = tgid;
+    data->ct = bpf_ktime_get_ns();
+    bpf_get_current_comm(&data->name, TASK_COMM_LEN);
 }
 
 static __always_inline int netdata_vfs_not_update_apps()

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -298,7 +298,7 @@ static pid_t ebpf_update_tables(int global, int apps)
 {
     pid_t pid = ebpf_fill_global(global);
 
-    struct netdata_vfs_stat_t stats = { .pid_tgid = (__u64)pid, .pid = pid, .pad = 0, .write_call = 1,
+    struct netdata_vfs_stat_t stats = { .ct = 0, .name = "vfs", .write_call = 1,
                                         .writev_call = 1, .read_call = 1, .readv_call = 1, .unlink_call = 1,
                                         .fsync_call = 1, .open_call = 1, .create_call = 1, .write_bytes = 1,
                                         .writev_bytes = 1, .readv_bytes = 1, .read_bytes = 1, .write_err = 1,


### PR DESCRIPTION
##### Summary
Sync current repository with `kernel-collector` repository.

##### Test Plan
1. Clone this branch
2. Run the following commands:
```sh
# git submodule update --init --recursive
# make clean; make
# cd src/tests
# sh run_tests.sh
```
3. Verify that you do not have any `libbpf` error inside `error.log`.

##### Additional information

| Linux Distribution |   Environment  |Kernel Version |    Error    | Success |
|--------------------|----------------|---------------|-------------|---------|
| Slackware current  | Bare metal  | 6.1.52      | [error.log](https://github.com/netdata/ebpf-co-re/files/12591860/error.log) | [success.log](https://github.com/netdata/ebpf-co-re/files/12591861/success.log) |
|Arch Linux | Libvirtt | 6.5.2-arch1-1 | [error.log](https://github.com/netdata/ebpf-co-re/files/12592154/error.log) | [success.log](https://github.com/netdata/ebpf-co-re/files/12592155/success.log) | 
| Ubuntu 22.04 | Libvirt | 5.15.0-76-generic|[error.log](https://github.com/netdata/ebpf-co-re/files/12592507/error.log) | [success.log](https://github.com/netdata/ebpf-co-re/files/12592514/success.log) |
| Debian 11 | Libvirt | 5.10.0-25-amd64 | [error.log](https://github.com/netdata/ebpf-co-re/files/12597362/error.log) | [success.log](https://github.com/netdata/ebpf-co-re/files/12597363/success.log) | 
| Alma 9 | Libvirt | 5.14.0-284.25.1.el9_2.x86_64 | [error.log](https://github.com/netdata/ebpf-co-re/files/12600026/error.log) | [success.log](https://github.com/netdata/ebpf-co-re/files/12600027/success.log) | 
|Alma 8 | Libvirt | 4.18.0-477.21.1.el8_8.x86_64|[error.log](https://github.com/netdata/ebpf-co-re/files/12600361/error.log) | [success.log](https://github.com/netdata/ebpf-co-re/files/12600362/success.log) | 