### PR TITLE
Remove release_task from VFS

### DIFF
--- a/src/vfs.bpf.c
+++ b/src/vfs.bpf.c
@@ -370,23 +370,6 @@ static __always_inline int netdata_common_vfs_create(int ret)
     return 0;
 }
 
-static __always_inline int netdata_release_task_vfs()
-{
-    struct netdata_vfs_stat_t *removeme;
-    __u32 key = 0;
-    if (netdata_vfs_not_update_apps())
-        return 0;
-
-    removeme = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
-    if (removeme) {
-        bpf_map_delete_elem(&tbl_vfs_pid, &key);
-
-        libnetdata_update_global(&vfs_ctrl, NETDATA_CONTROLLER_PID_TABLE_DEL, 1);
-    }
-
-    return 0;
-}
-
 /************************************************************************************
  *     
  *                            VFS Section (kprobe)
@@ -527,12 +510,6 @@ int BPF_KRETPROBE(netdata_vfs_create_kretprobe)
     int ret = (int)PT_REGS_RC(ctx);
 
     return netdata_common_vfs_create(ret);
-}
-
-SEC("kprobe/release_task")
-int BPF_KRETPROBE(netdata_vfs_release_task_kprobe)
-{
-    return netdata_release_task_vfs();
 }
 
 /************************************************************************************
@@ -682,12 +659,6 @@ int BPF_PROG(netdata_vfs_create_fexit, struct inode *dir, struct dentry *dentry,
     return netdata_common_vfs_create(ret);
 }
 */
-
-SEC("fentry/release_task")
-int BPF_PROG(netdata_vfs_release_task_fentry)
-{
-    return netdata_release_task_vfs();
-}
 
 char _license[] SEC("license") = "GPL";
 

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -22,8 +22,7 @@ char *function_list[] = { "vfs_write",
                           "vfs_unlink",
                           "vfs_fsync",
                           "vfs_open",
-                          "vfs_create",
-                          "release_task"
+                          "vfs_create"
 };
 // This preprocessor is defined here, because it is not useful in kernel-colector
 #define NETDATA_VFS_RELEASE_TASK 8
@@ -46,7 +45,6 @@ static inline void ebpf_disable_probes(struct vfs_bpf *obj)
     bpf_program__set_autoload(obj->progs.netdata_vfs_open_kretprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_vfs_create_kprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_vfs_create_kretprobe, false);
-    bpf_program__set_autoload(obj->progs.netdata_vfs_release_task_kprobe, false);
 }
 
 static inline void ebpf_disable_trampoline(struct vfs_bpf *obj)
@@ -66,7 +64,6 @@ static inline void ebpf_disable_trampoline(struct vfs_bpf *obj)
     bpf_program__set_autoload(obj->progs.netdata_vfs_open_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_vfs_open_fexit, false);
     bpf_program__set_autoload(obj->progs.netdata_vfs_create_fentry, false);
-    bpf_program__set_autoload(obj->progs.netdata_vfs_release_task_fentry, false);
 //    bpf_program__set_autoload(obj->progs.netdata_vfs_create_fexit, false);
 }
 
@@ -116,9 +113,6 @@ static void ebpf_set_trampoline_target(struct vfs_bpf *obj)
 
     bpf_program__set_attach_target(obj->progs.netdata_vfs_create_fentry, 0,
                                    function_list[NETDATA_VFS_CREATE]);
-
-    bpf_program__set_attach_target(obj->progs.netdata_vfs_release_task_fentry, 0,
-                                   function_list[NETDATA_VFS_RELEASE_TASK]);
 
 //    bpf_program__set_attach_target(obj->progs.netdata_vfs_create_fexit, 0,
 //                                   function_list[NETDATA_VFS_CREATE]);
@@ -230,11 +224,6 @@ static int ebpf_attach_probes(struct vfs_bpf *obj)
     if (ret)
         return -1;
  
-    obj->links.netdata_vfs_release_task_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_vfs_release_task_kprobe,
-                                                                           true, function_list[NETDATA_VFS_RELEASE_TASK]);
-    ret = libbpf_get_error(obj->links.netdata_vfs_release_task_kprobe);
-    if (ret)
-        return -1;
     return 0;
 }
 


### PR DESCRIPTION
##### Summary
We are removing this target to keep compatibility between branches and reduce overload.

##### Test Plan
1. Clone this branch
2. Run the following commands:
```sh
# git submodule update --init --recursive
# make clean; make
# cd src/tests
# sh run_tests.sh
```
3. Verify that you do not have any `libbpf` error inside `error.log`.

##### Additional information

| Linux Distribution |   Environment  |Kernel Version |    Error    | Success |
|--------------------|----------------|---------------|-------------|---------|
| Slackware current  | Bare metal  | 6.1.52      | [error.log](https://github.com/netdata/ebpf-co-re/files/12615082/error.log)  | [success.log](https://github.com/netdata/ebpf-co-re/files/12615083/success.log)|