### PR TITLE
Address threads currently loaded by default 

### DIFF
--- a/src/cachestat.c
+++ b/src/cachestat.c
@@ -40,8 +40,7 @@ static ebpf_specify_name_t cachestat_names[] = { {.program_name = "netdata_folio
 char *cachestat_fcnt[] = { "add_to_page_cache_lru",
                      "mark_page_accessed",
                      NULL, // Filled after to discover available functions
-                     "mark_buffer_dirty",
-                     "release_task"
+                     "mark_buffer_dirty"
 };
 // This preprocessor is defined here, because it is not useful in kernel-colector
 #define NETDATA_CACHESTAT_RELEASE_TASK 4
@@ -54,7 +53,6 @@ static inline void netdata_ebpf_disable_probe(struct cachestat_bpf *obj)
     bpf_program__set_autoload(obj->progs.netdata_set_page_dirty_kprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_account_page_dirtied_kprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_mark_buffer_dirty_kprobe, false);
-    bpf_program__set_autoload(obj->progs.netdata_release_task_kprobe, false);
 }
 
 static inline void netdata_ebpf_disable_specific_probe(struct cachestat_bpf *obj)
@@ -79,7 +77,6 @@ static inline void netdata_ebpf_disable_trampoline(struct cachestat_bpf *obj)
     bpf_program__set_autoload(obj->progs.netdata_set_page_dirty_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_account_page_dirtied_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_mark_buffer_dirty_fentry, false);
-    bpf_program__set_autoload(obj->progs.netdata_release_task_fentry, false);
 }
 
 static inline void netdata_ebpf_disable_specific_trampoline(struct cachestat_bpf *obj)
@@ -117,9 +114,6 @@ static inline void netdata_set_trampoline_target(struct cachestat_bpf *obj)
 
     bpf_program__set_attach_target(obj->progs.netdata_mark_buffer_dirty_fentry, 0,
                                    cachestat_fcnt[NETDATA_KEY_CALLS_MARK_BUFFER_DIRTY]);
-
-    bpf_program__set_attach_target(obj->progs.netdata_release_task_fentry, 0,
-                                   cachestat_fcnt[NETDATA_CACHESTAT_RELEASE_TASK]);
 }
 
 static inline int netdata_attach_kprobe_target(struct cachestat_bpf *obj)
@@ -162,12 +156,6 @@ static inline int netdata_attach_kprobe_target(struct cachestat_bpf *obj)
     obj->links.netdata_mark_buffer_dirty_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_mark_buffer_dirty_kprobe,
                                                                     false, cachestat_fcnt[NETDATA_KEY_CALLS_MARK_BUFFER_DIRTY]);
     ret = libbpf_get_error(obj->links.netdata_mark_buffer_dirty_kprobe);
-    if (ret)
-        goto endnakt;
-
-    obj->links.netdata_release_task_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_release_task_kprobe,
-                                                                    false, cachestat_fcnt[NETDATA_CACHESTAT_RELEASE_TASK]);
-    ret = libbpf_get_error(obj->links.netdata_release_task_kprobe);
     if (ret)
         goto endnakt;
 

--- a/src/fd.c
+++ b/src/fd.c
@@ -43,8 +43,7 @@ static ebpf_specify_name_t open_names[] = { {.program_name = "netdata_sys_open_k
                                              {.program_name = NULL}};
 
 char *function_list[] = { NULL,
-                          NULL,
-                          "release_task"
+                          NULL
                         };
 // This preprocessor is defined here, because it is not useful in kernel-colector
 #define NETDATA_FD_RELEASE_TASK 2
@@ -53,7 +52,6 @@ static inline void ebpf_disable_probes(struct fd_bpf *obj)
 {
     bpf_program__set_autoload(obj->progs.netdata_sys_open_kprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_sys_open_kretprobe, false);
-    bpf_program__set_autoload(obj->progs.netdata_release_task_fd_kprobe, false);
     if (close_names[0].optional) {
         bpf_program__set_autoload(obj->progs.netdata___close_fd_kretprobe, false);
         bpf_program__set_autoload(obj->progs.netdata___close_fd_kprobe, false);
@@ -84,7 +82,6 @@ static inline void ebpf_disable_trampoline(struct fd_bpf *obj)
     bpf_program__set_autoload(obj->progs.netdata_close_fd_fexit, false);
     bpf_program__set_autoload(obj->progs.netdata___close_fd_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata___close_fd_fexit, false);
-    bpf_program__set_autoload(obj->progs.netdata_release_task_fd_fentry, false);
 }
 
 static inline void ebpf_disable_specific_trampoline(struct fd_bpf *obj)
@@ -105,9 +102,6 @@ static void ebpf_set_trampoline_target(struct fd_bpf *obj)
 
     bpf_program__set_attach_target(obj->progs.netdata_sys_open_fexit, 0,
                                    function_list[NETDATA_FD_OPEN]);
-
-    bpf_program__set_attach_target(obj->progs.netdata_release_task_fd_fentry, 0,
-                                   function_list[NETDATA_FD_RELEASE_TASK]);
 
     if (close_names[0].optional) {
         bpf_program__set_attach_target(obj->progs.netdata_close_fd_fentry, 0,

--- a/src/process.bpf.c
+++ b/src/process.bpf.c
@@ -40,6 +40,13 @@ struct {
 
 static __always_inline void netdata_fill_common_process_data(struct netdata_pid_stat_t *data)
 {
+    data->ct = bpf_ktime_get_ns();
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,11,0))
+    bpf_get_current_comm(&data->name, TASK_COMM_LEN);
+#else
+    data->name[0] = '\0';
+#endif
+
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     __u32 tgid = (__u32)( 0x00000000FFFFFFFF & pid_tgid);
 

--- a/src/shm.c
+++ b/src/shm.c
@@ -21,8 +21,7 @@
 char *syscalls[] = { "__x64_sys_shmget",
                      "__x64_sys_shmat",
                      "__x64_sys_shmdt",
-                     "__x64_sys_shmctl",
-                     "release_task"
+                     "__x64_sys_shmctl"
                                     };
 // This preprocessor is defined here, because it is not useful in kernel-colector
 #define NETDATA_SHM_RELEASE_TASK 4
@@ -41,7 +40,6 @@ static void ebpf_disable_kprobe(struct shm_bpf *obj)
     bpf_program__set_autoload(obj->progs.netdata_shmat_probe, false);
     bpf_program__set_autoload(obj->progs.netdata_shmdt_probe, false);
     bpf_program__set_autoload(obj->progs.netdata_shmctl_probe, false);
-    bpf_program__set_autoload(obj->progs.netdata_shm_release_task_probe, false);
 }
 
 static void ebpf_disable_trampoline(struct shm_bpf *obj)
@@ -50,7 +48,6 @@ static void ebpf_disable_trampoline(struct shm_bpf *obj)
     bpf_program__set_autoload(obj->progs.netdata_shmat_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_shmdt_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_shmctl_fentry, false);
-    bpf_program__set_autoload(obj->progs.netdata_shm_release_task_fentry, false);
 }
 
 static int ebpf_attach_kprobe(struct shm_bpf *obj)
@@ -79,13 +76,6 @@ static int ebpf_attach_kprobe(struct shm_bpf *obj)
     if (ret)
         return -1;
 
-    obj->links.netdata_shm_release_task_probe = bpf_program__attach_kprobe(obj->progs.netdata_shm_release_task_probe,
-                                                                false, syscalls[NETDATA_SHM_RELEASE_TASK]);
-    ret = libbpf_get_error(obj->links.netdata_shm_release_task_probe);
-    if (ret)
-        return -1;
-
-
     return 0;
 }
 
@@ -102,9 +92,6 @@ static void ebpf_set_trampoline_target(struct shm_bpf *obj)
 
     bpf_program__set_attach_target(obj->progs.netdata_shmctl_fentry, 0,
                                    syscalls[NETDATA_KEY_SHMCTL_CALL]);
-
-    bpf_program__set_attach_target(obj->progs.netdata_shm_release_task_fentry, 0,
-                                   syscalls[NETDATA_SHM_RELEASE_TASK]);
 }
 
 static inline int ebpf_load_and_attach(struct shm_bpf *obj, int selector)

--- a/src/swap.c
+++ b/src/swap.c
@@ -16,8 +16,7 @@
 #include "swap.skel.h"
 
 char *function_list[] = { "swap_readpage",
-                          "swap_writepage",
-                          "release_task"
+                          "swap_writepage"
 };
 // This preprocessor is defined here, because it is not useful in kernel-colector
 #define NETDATA_SWAP_RELEASE_TASK 2
@@ -26,14 +25,12 @@ static void netdata_ebpf_disable_probe(struct swap_bpf *obj)
 {
     bpf_program__set_autoload(obj->progs.netdata_swap_readpage_probe, false);
     bpf_program__set_autoload(obj->progs.netdata_swap_writepage_probe, false);
-    bpf_program__set_autoload(obj->progs.netdata_swap_release_task_probe, false);
 }
 
 static void netdata_ebpf_disable_trampoline(struct swap_bpf *obj)
 {
     bpf_program__set_autoload(obj->progs.netdata_swap_readpage_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_swap_writepage_fentry, false);
-    bpf_program__set_autoload(obj->progs.netdata_release_task_fentry, false);
 }
 
 static void netdata_set_trampoline_target(struct swap_bpf *obj)
@@ -43,9 +40,6 @@ static void netdata_set_trampoline_target(struct swap_bpf *obj)
 
     bpf_program__set_attach_target(obj->progs.netdata_swap_writepage_fentry, 0,
                                    function_list[NETDATA_KEY_SWAP_WRITEPAGE_CALL]);
-
-    bpf_program__set_attach_target(obj->progs.netdata_release_task_fentry, 0,
-                                   function_list[NETDATA_SWAP_RELEASE_TASK]);
 }
 
 static int attach_kprobe(struct swap_bpf *obj)
@@ -59,12 +53,6 @@ static int attach_kprobe(struct swap_bpf *obj)
     obj->links.netdata_swap_writepage_probe = bpf_program__attach_kprobe(obj->progs.netdata_swap_writepage_probe,
                                                                          false, function_list[NETDATA_KEY_SWAP_WRITEPAGE_CALL]);
     ret = libbpf_get_error(obj->links.netdata_swap_writepage_probe);
-    if (ret)
-        return -1;
-
-    obj->links.netdata_swap_release_task_probe = bpf_program__attach_kprobe(obj->progs.netdata_swap_release_task_probe,
-                                                                       false, function_list[NETDATA_SWAP_RELEASE_TASK]);
-    ret = libbpf_get_error(obj->links.netdata_swap_release_task_probe);
     if (ret)
         return -1;
 


### PR DESCRIPTION
##### Summary
Sync current repo with `kernel-collector` repo.

##### Test Plan
1. Clone this branch
2. Run the following commands:
```sh
# git submodule update --init --recursive
# make clean; make
# cd src/tests
# sh run_tests.sh
```
3. Verify that you do not have any `libbpf` error inside `error.log`.

##### Additional information

| Linux Distribution |   Environment  |Kernel Version |    Error    | Success |
|--------------------|----------------|---------------|-------------|---------|
| Slackware current  | Bare metal  | 6.1.53      |[slackware_6_1_error.log](https://github.com/netdata/ebpf-co-re/files/12641621/slackware_6_1_error.log) | [slackware_6_1_success.log](https://github.com/netdata/ebpf-co-re/files/12641622/slackware_6_1_success.log)|
| Arch Linux | Libvirt | 6.5.3 | [arch_6_5_error.log](https://github.com/netdata/ebpf-co-re/files/12641754/arch_6_5_error.log) | [arch_6_5_success.log](https://github.com/netdata/ebpf-co-re/files/12641755/arch_6_5_success.log) | 
|Ubuntu 22.04 | Libvirt | 5.15.0-76-generic | [ubuntu_5_15_error.log](https://github.com/netdata/ebpf-co-re/files/12641869/ubuntu_5_15_error.log) | [ubuntu_5_15_success.log](https://github.com/netdata/ebpf-co-re/files/12641870/ubuntu_5_15_success.log) | 
|Debian 11 | Libvirt | 5.10.191-1| [debian_5_10_error.log](https://github.com/netdata/ebpf-co-re/files/12642884/debian_5_10_error.log) | [debian_5_10_success.log](https://github.com/netdata/ebpf-co-re/files/12642885/debian_5_10_success.log) | 
|Alma 8 | Libvirt | 4.18.0-477.21.1.el8_8.x86_64 | [alma_4_18_error.log](https://github.com/netdata/ebpf-co-re/files/12643287/alma_4_18_error.log) | [alma_4_18_success.log](https://github.com/netdata/ebpf-co-re/files/12643288/alma_4_18_success.log) | 