### PR TITLE
Update algorithms

### DIFF
--- a/src/cachestat.bpf.c
+++ b/src/cachestat.bpf.c
@@ -61,7 +61,7 @@ static __always_inline int netdata_common_page_cache_lru()
     __u32 tgid = 0;
     fill = netdata_get_pid_structure(&key, &tgid, &cstat_ctrl, &cstat_pid);
     if (fill) {
-        libnetdata_update_u64(&fill->misses, 1);
+        libnetdata_update_s64(&fill->misses, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
         ibnetdata_update_uid_gid(&data.uid, &data.gid);
@@ -88,7 +88,7 @@ static __always_inline int netdata_common_page_accessed()
     __u32 tgid = 0;
     fill = netdata_get_pid_structure(&key, &tgid, &cstat_ctrl, &cstat_pid);
     if (fill) {
-        libnetdata_update_u64(&fill->total, 1);
+        libnetdata_update_s64(&fill->total, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
         libnetdata_update_uid_gid(&data.uid, &data.gid);

--- a/src/cachestat.bpf.c
+++ b/src/cachestat.bpf.c
@@ -64,7 +64,7 @@ static __always_inline int netdata_common_page_cache_lru()
         libnetdata_update_s64(&fill->misses, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
-        ibnetdata_update_uid_gid(&data.uid, &data.gid);
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
         
         data.misses = 1;
@@ -143,7 +143,7 @@ static __always_inline int netdata_common_buffer_dirty()
     __u32 tgid = 0;
     fill = netdata_get_pid_structure(&key, &tgid, &cstat_ctrl, &cstat_pid);
     if (fill) {
-        libnetdata_update_u64(&fill->total, -1);
+        libnetdata_update_s64(&fill->total, -1);
         libnetdata_update_u64(&fill->dirty, 1);
     } else {
         data.ct = bpf_ktime_get_ns();

--- a/src/cachestat.bpf.c
+++ b/src/cachestat.bpf.c
@@ -38,10 +38,8 @@ struct {
  *
  ***********************************************************************************/
 
-static __always_inline int netdata_cachetat_not_update_apps(__u32 idx)
+static __always_inline int netdata_cachetat_not_update_apps()
 {
-    libnetdata_update_global(&cstat_global, idx, 1);
-
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
     __u32 *apps = bpf_map_lookup_elem(&cstat_ctrl ,&key);
     if (apps && *apps)
@@ -54,18 +52,22 @@ static __always_inline int netdata_common_page_cache_lru()
 {
     netdata_cachestat_t *fill, data = {};
 
-    if (netdata_cachetat_not_update_apps(NETDATA_KEY_CALLS_ADD_TO_PAGE_CACHE_LRU))
+    libnetdata_update_global(&cstat_global, NETDATA_KEY_MISSES, 1);
+
+    if (netdata_cachetat_not_update_apps())
         return 0;
 
     __u32 key = 0;
-    fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
+    __u32 tgid = 0;
+    fill = netdata_get_pid_structure(&key, &tgid, &cstat_ctrl, &cstat_pid);
     if (fill) {
-        libnetdata_update_u64(&fill->add_to_page_cache_lru, 1);
+        libnetdata_update_u64(&fill->misses, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        ibnetdata_update_uid_gid(&data.uid, &data.gid);
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
         
-        data.add_to_page_cache_lru = 1;
+        data.misses = 1;
         bpf_map_update_elem(&cstat_pid, &key, &data, BPF_ANY);
 
         libnetdata_update_global(&cstat_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
@@ -77,19 +79,22 @@ static __always_inline int netdata_common_page_cache_lru()
 static __always_inline int netdata_common_page_accessed()
 {
     netdata_cachestat_t *fill, data = {};
+    libnetdata_update_global(&cstat_global, NETDATA_KEY_TOTAL, 1);
 
-    if (netdata_cachetat_not_update_apps(NETDATA_KEY_CALLS_MARK_PAGE_ACCESSED))
+    if (netdata_cachetat_not_update_apps())
         return 0;
 
     __u32 key = 0;
-    fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
+    __u32 tgid = 0;
+    fill = netdata_get_pid_structure(&key, &tgid, &cstat_ctrl, &cstat_pid);
     if (fill) {
-        libnetdata_update_u64(&fill->mark_page_accessed, 1);
+        libnetdata_update_u64(&fill->total, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
         
-        data.mark_page_accessed = 1;
+        data.total = 1;
         bpf_map_update_elem(&cstat_pid, &key, &data, BPF_ANY);
 
         libnetdata_update_global(&cstat_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
@@ -102,18 +107,21 @@ static __always_inline int netdata_common_page_dirtied()
 {
     netdata_cachestat_t *fill, data = {};
 
-    if (netdata_cachetat_not_update_apps(NETDATA_KEY_CALLS_ACCOUNT_PAGE_DIRTIED))
+    libnetdata_update_sglobal(&cstat_global, NETDATA_KEY_MISSES, -1);
+    if (netdata_cachetat_not_update_apps())
         return 0;
 
     __u32 key = 0;
-    fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
+    __u32 tgid = 0;
+    fill = netdata_get_pid_structure(&key, &tgid, &cstat_ctrl, &cstat_pid);
     if (fill) {
-        libnetdata_update_u64(&fill->account_page_dirtied, 1);
+        libnetdata_update_s64(&fill->misses, -1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
         
-        data.account_page_dirtied = 1;
+        data.misses = -1;
         bpf_map_update_elem(&cstat_pid, &key, &data, BPF_ANY);
 
         libnetdata_update_global(&cstat_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
@@ -126,18 +134,24 @@ static __always_inline int netdata_common_buffer_dirty()
 {
     netdata_cachestat_t *fill, data = {};
 
-    if (netdata_cachetat_not_update_apps(NETDATA_KEY_CALLS_MARK_BUFFER_DIRTY))
+    libnetdata_update_sglobal(&cstat_global, NETDATA_KEY_TOTAL, -1);
+    libnetdata_update_global(&cstat_global, NETDATA_KEY_DIRTY, 1);
+    if (netdata_cachetat_not_update_apps())
         return 0;
 
     __u32 key = 0;
-    fill = netdata_get_pid_structure(&key, &cstat_ctrl, &cstat_pid);
+    __u32 tgid = 0;
+    fill = netdata_get_pid_structure(&key, &tgid, &cstat_ctrl, &cstat_pid);
     if (fill) {
-        libnetdata_update_u64(&fill->mark_buffer_dirty, 1);
+        libnetdata_update_u64(&fill->total, -1);
+        libnetdata_update_u64(&fill->dirty, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
         
-        data.mark_buffer_dirty = 1;
+        data.dirty = 1;
+        data.total = -1;
         bpf_map_update_elem(&cstat_pid, &key, &data, BPF_ANY);
 
         libnetdata_update_global(&cstat_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);

--- a/src/cachestat.c
+++ b/src/cachestat.c
@@ -203,8 +203,7 @@ static pid_t ebpf_update_tables(int global, int apps)
     if (ret)
         fprintf(stderr, "Cannot insert value to global table.");
 
-    netdata_cachestat_t stats = { .add_to_page_cache_lru = 1, .mark_page_accessed = 1,
-                                        .account_page_dirtied = 1, .mark_buffer_dirty = 1 };
+    netdata_cachestat_t stats = { .ct = 0, .uid = 0, .tgid = 0, .total = 1, .misses = 1, .dirty = 1 };
 
     idx = (pid_t)pid;
     ret = bpf_map_update_elem(apps, &idx, &stats, 0);

--- a/src/dc.bpf.c
+++ b/src/dc.bpf.c
@@ -64,6 +64,7 @@ static __always_inline int netdata_common_lookup_fast()
         libnetdata_update_u64(&fill->references, 1);
     } else {
         data.references = 1;
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
         bpf_map_update_elem(&dcstat_pid, &key, &data, BPF_ANY);
 
@@ -89,6 +90,7 @@ static __always_inline int netdata_common_d_lookup(long ret)
         libnetdata_update_u64(&fill->slow, 1);
     } else {
         data.slow = 1;
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
         bpf_map_update_elem(&dcstat_pid, &key, &data, BPF_ANY);
 
@@ -101,12 +103,6 @@ static __always_inline int netdata_common_d_lookup(long ret)
         fill = netdata_get_pid_structure(&key, &tgid, &dcstat_ctrl, &dcstat_pid);
         if (fill) {
             libnetdata_update_u64(&fill->missed, 1);
-        } else {
-            data.missed = 1;
-            bpf_get_current_comm(&data.name, TASK_COMM_LEN);
-            bpf_map_update_elem(&dcstat_pid, &key, &data, BPF_ANY);
-
-            libnetdata_update_global(&dcstat_ctrl, NETDATA_CONTROLLER_PID_TABLE_ADD, 1);
         }
     }
 

--- a/src/dc.bpf.c
+++ b/src/dc.bpf.c
@@ -52,13 +52,14 @@ static __always_inline int netdata_common_lookup_fast()
 {
     netdata_dc_stat_t *fill, data = {};
     __u32 key = 0;
+    __u32 tgid = 0;
 
     libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_REFERENCE, 1);
 
     if (netdata_dc_not_update_apps())
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &dcstat_ctrl, &dcstat_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &dcstat_ctrl, &dcstat_pid);
     if (fill) {
         libnetdata_update_u64(&fill->references, 1);
     } else {
@@ -76,13 +77,14 @@ static __always_inline int netdata_common_d_lookup(long ret)
 {
     netdata_dc_stat_t *fill, data = {};
     __u32 key = 0;
+    __u32 tgid = 0;
 
     libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_SLOW, 1);
 
     if (netdata_dc_not_update_apps())
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &dcstat_ctrl, &dcstat_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &dcstat_ctrl, &dcstat_pid);
     if (fill) {
         libnetdata_update_u64(&fill->slow, 1);
     } else {
@@ -96,7 +98,7 @@ static __always_inline int netdata_common_d_lookup(long ret)
     // file not found
     if (!ret) {
         libnetdata_update_global(&dcstat_global, NETDATA_KEY_DC_MISS, 1);
-        fill = netdata_get_pid_structure(&key, &dcstat_ctrl, &dcstat_pid);
+        fill = netdata_get_pid_structure(&key, &tgid, &dcstat_ctrl, &dcstat_pid);
         if (fill) {
             libnetdata_update_u64(&fill->missed, 1);
         } else {

--- a/src/fd.bpf.c
+++ b/src/fd.bpf.c
@@ -71,6 +71,7 @@ static __always_inline int netdata_apps_do_sys_openat2(long ret)
             libnetdata_update_u32(&fill->open_err, 1) ;
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
         data.open_call = 1;
         if (ret < 0)
@@ -110,6 +111,7 @@ static __always_inline int netdata_apps_close_fd(int ret)
             libnetdata_update_u32(&fill->close_err, 1) ;
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
         data.close_call = 1;
         if (ret < 0)

--- a/src/fd.bpf.c
+++ b/src/fd.bpf.c
@@ -62,8 +62,9 @@ static __always_inline int netdata_apps_do_sys_openat2(long ret)
     if (!netdata_are_apps_enabled())
         return 0;
 
-    __u32 key;
-    fill = netdata_get_pid_structure(&key, &fd_ctrl, &tbl_fd_pid);
+    __u32 key = 0;
+    __u32 tgid = 0;
+    fill = netdata_get_pid_structure(&key, &tgid, &fd_ctrl, &tbl_fd_pid);
     if (fill) {
         libnetdata_update_u32(&fill->open_call, 1) ;
         if (ret < 0) 
@@ -100,8 +101,9 @@ static __always_inline int netdata_apps_close_fd(int ret)
     if (!netdata_are_apps_enabled())
         return 0;
 
-    __u32 key;
-    fill = netdata_get_pid_structure(&key, &fd_ctrl, &tbl_fd_pid);
+    __u32 key = 0;
+    __u32 tgid = 0;
+    fill = netdata_get_pid_structure(&key, &tgid, &fd_ctrl, &tbl_fd_pid);
     if (fill) {
         libnetdata_update_u32(&fill->close_call, 1) ;
         if (ret < 0)

--- a/src/netdata_core_common.h
+++ b/src/netdata_core_common.h
@@ -35,6 +35,13 @@ typedef struct ebpf_specify_name {
     bool retprobe;
 } ebpf_specify_name_t;
 
+enum cachestat_counters_user_ring {
+    NETDATA_KEY_CALLS_ADD_TO_PAGE_CACHE_LRU,
+    NETDATA_KEY_CALLS_MARK_PAGE_ACCESSED,
+    NETDATA_KEY_CALLS_ACCOUNT_PAGE_DIRTIED,
+    NETDATA_KEY_CALLS_MARK_BUFFER_DIRTY
+};
+
 /**
  * Update names
  *

--- a/src/process.bpf.c
+++ b/src/process.bpf.c
@@ -65,7 +65,7 @@ static __always_inline int netdata_process_not_update_apps()
 static __always_inline int netdata_common_release_task()
 {
     struct netdata_pid_stat_t *fill;
-    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 key = 0;
     __u32 tgid = 0;
 
     libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_RELEASE_TASK, 1);
@@ -85,7 +85,7 @@ static __always_inline int netdata_common_release_task()
 
 static __always_inline int netdata_common_fork_clone(int ret)
 {
-    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 key = 0;
     __u32 tgid = 0;
     struct netdata_pid_stat_t data = { };
     struct netdata_pid_stat_t *fill;
@@ -128,13 +128,14 @@ SEC("tracepoint/sched/sched_process_exit")
 int netdata_tracepoint_sched_process_exit(struct netdata_sched_process_exit *ptr)
 {
     struct netdata_pid_stat_t *fill;
-    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 key = 0;
+    __u32 tgid = 0;
 
     libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_DO_EXIT, 1);
     if (netdata_process_not_update_apps())
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &process_ctrl, &tbl_pid_stats);
+    fill = netdata_get_pid_structure(&key, &tgid, &process_ctrl, &tbl_pid_stats);
     if (fill) {
         libnetdata_update_u32(&fill->exit_call, 1) ;
     } 
@@ -148,7 +149,7 @@ int netdata_tracepoint_sched_process_exec(struct netdata_sched_process_exec *ptr
 {
     struct netdata_pid_stat_t data = { };
     struct netdata_pid_stat_t *fill;
-    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 key = 0;
     __u32 tgid = 0;
     // This is necessary, because it represents the main function to start a thread
     libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_PROCESS, 1);
@@ -179,7 +180,7 @@ int netdata_tracepoint_sched_process_fork(struct netdata_sched_process_fork *ptr
 {
     struct netdata_pid_stat_t data = { };
     struct netdata_pid_stat_t *fill;
-    __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 key = 0;
     __u32 tgid = 0;
 
     libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_PROCESS, 1);

--- a/src/process.bpf.c
+++ b/src/process.bpf.c
@@ -66,12 +66,13 @@ static __always_inline int netdata_common_release_task()
 {
     struct netdata_pid_stat_t *fill;
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 tgid = 0;
 
     libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_RELEASE_TASK, 1);
     if (netdata_process_not_update_apps())
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &process_ctrl, &tbl_pid_stats);
+    fill = netdata_get_pid_structure(&key, &tgid, &process_ctrl, &tbl_pid_stats);
     if (fill) {
         libnetdata_update_u32(&fill->release_call, 1) ;
         fill->removeme = 1;
@@ -85,6 +86,7 @@ static __always_inline int netdata_common_release_task()
 static __always_inline int netdata_common_fork_clone(int ret)
 {
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 tgid = 0;
     struct netdata_pid_stat_t data = { };
     struct netdata_pid_stat_t *fill;
 
@@ -95,7 +97,7 @@ static __always_inline int netdata_common_fork_clone(int ret)
     if (netdata_process_not_update_apps())
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &process_ctrl, &tbl_pid_stats);
+    fill = netdata_get_pid_structure(&key, &tgid, &process_ctrl, &tbl_pid_stats);
     if (fill) {
         fill->release_call = 0;
 
@@ -147,6 +149,7 @@ int netdata_tracepoint_sched_process_exec(struct netdata_sched_process_exec *ptr
     struct netdata_pid_stat_t data = { };
     struct netdata_pid_stat_t *fill;
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 tgid = 0;
     // This is necessary, because it represents the main function to start a thread
     libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_PROCESS, 1);
 
@@ -154,7 +157,7 @@ int netdata_tracepoint_sched_process_exec(struct netdata_sched_process_exec *ptr
     if (netdata_process_not_update_apps())
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &process_ctrl, &tbl_pid_stats);
+    fill = netdata_get_pid_structure(&key, &tgid, &process_ctrl, &tbl_pid_stats);
     if (fill) {
         fill->release_call = 0;
         libnetdata_update_u32(&fill->create_process, 1) ;
@@ -177,6 +180,7 @@ int netdata_tracepoint_sched_process_fork(struct netdata_sched_process_fork *ptr
     struct netdata_pid_stat_t data = { };
     struct netdata_pid_stat_t *fill;
     __u32 key = NETDATA_CONTROLLER_APPS_ENABLED;
+    __u32 tgid = 0;
 
     libnetdata_update_global(&tbl_total_stats, NETDATA_KEY_CALLS_PROCESS, 1);
 
@@ -190,7 +194,7 @@ int netdata_tracepoint_sched_process_fork(struct netdata_sched_process_fork *ptr
     if (netdata_process_not_update_apps())
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &process_ctrl, &tbl_pid_stats);
+    fill = netdata_get_pid_structure(&key, &tgid, &process_ctrl, &tbl_pid_stats);
     if (fill) {
         fill->release_call = 0;
         libnetdata_update_u32(&fill->create_process, 1);

--- a/src/shm.bpf.c
+++ b/src/shm.bpf.c
@@ -75,6 +75,7 @@ static __always_inline int netdata_update_apps(__u32 idx)
         netdata_update_stored_data(fill, idx);
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
 
         netdata_set_structure_value(&data, idx);

--- a/src/shm.bpf.c
+++ b/src/shm.bpf.c
@@ -68,8 +68,9 @@ static __always_inline int netdata_update_apps(__u32 idx)
 {
     netdata_shm_t data = {};
 
-    __u32 key;
-    netdata_shm_t *fill = netdata_get_pid_structure(&key, &shm_ctrl, &tbl_pid_shm);
+    __u32 key = 0;
+    __u32 tgid = 0;
+    netdata_shm_t *fill = netdata_get_pid_structure(&key, &tgid, &shm_ctrl, &tbl_pid_shm);
     if (fill) {
         netdata_update_stored_data(fill, idx);
     } else {

--- a/src/socket.bpf.c
+++ b/src/socket.bpf.c
@@ -109,7 +109,8 @@ static __always_inline short unsigned int set_idx_value(netdata_socket_idx_t *ns
     if (nsi->dport == 0)
         return AF_UNSPEC;
 
-    nsi->pid = netdata_get_pid(&socket_ctrl);
+    __u32 tgid = 0;
+    nsi->pid = netdata_get_pid(&socket_ctrl, &tgid);
 
     return family;
 }

--- a/src/swap.bpf.c
+++ b/src/swap.bpf.c
@@ -55,10 +55,11 @@ static __always_inline int common_readpage()
     libnetdata_update_global(&tbl_swap, NETDATA_KEY_SWAP_READPAGE_CALL, 1);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (netdata_swap_not_update_apps())
         return 0;
 
-    netdata_swap_access_t *fill = netdata_get_pid_structure(&key, &swap_ctrl, &tbl_pid_swap);
+    netdata_swap_access_t *fill = netdata_get_pid_structure(&key, &tgid, &swap_ctrl, &tbl_pid_swap);
     if (fill) {
         libnetdata_update_u64(&fill->read, 1);
     } else {
@@ -81,10 +82,11 @@ static __always_inline int common_writepage()
     libnetdata_update_global(&tbl_swap, NETDATA_KEY_SWAP_WRITEPAGE_CALL, 1);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (netdata_swap_not_update_apps())
         return 0;
 
-    netdata_swap_access_t *fill = netdata_get_pid_structure(&key, &swap_ctrl, &tbl_pid_swap);
+    netdata_swap_access_t *fill = netdata_get_pid_structure(&key, &tgid, &swap_ctrl, &tbl_pid_swap);
     if (fill) {
         libnetdata_update_u64(&fill->write, 1);
     } else {

--- a/src/swap.bpf.c
+++ b/src/swap.bpf.c
@@ -64,6 +64,7 @@ static __always_inline int common_readpage()
         libnetdata_update_u64(&fill->read, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
         data.read = 1;
 
@@ -91,6 +92,7 @@ static __always_inline int common_writepage()
         libnetdata_update_u64(&fill->write, 1);
     } else {
         data.ct = bpf_ktime_get_ns();
+        libnetdata_update_uid_gid(&data.uid, &data.gid);
         bpf_get_current_comm(&data.name, TASK_COMM_LEN);
         data.write = 1;
 

--- a/src/vfs.bpf.c
+++ b/src/vfs.bpf.c
@@ -71,10 +71,11 @@ static __always_inline int netdata_common_vfs_write(__u64 tot, ssize_t ret)
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_WRITE, tot);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (netdata_vfs_not_update_apps())
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->write_call, 1) ;
 
@@ -112,10 +113,11 @@ static __always_inline int netdata_common_vfs_writev(__u64 tot, ssize_t ret)
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_WRITEV, tot);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (netdata_vfs_not_update_apps())
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->writev_call, 1) ;
 
@@ -152,10 +154,11 @@ static __always_inline int netdata_common_vfs_read(__u64 tot, ssize_t ret)
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_READ, tot);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (netdata_vfs_not_update_apps())
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->read_call, 1) ;
 
@@ -192,10 +195,11 @@ static __always_inline int netdata_common_vfs_readv(__u64 tot, ssize_t ret)
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_BYTES_VFS_READV, tot);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (netdata_vfs_not_update_apps())
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->readv_call, 1) ;
 
@@ -231,10 +235,11 @@ static __always_inline int netdata_common_vfs_unlink(int ret)
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_UNLINK, 1);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (netdata_vfs_not_update_apps())
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->unlink_call, 1) ;
 
@@ -267,10 +272,11 @@ static __always_inline int netdata_common_vfs_fsync(int ret)
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_FSYNC, 1);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (netdata_vfs_not_update_apps())
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->fsync_call, 1) ;
 
@@ -304,10 +310,11 @@ static __always_inline int netdata_common_vfs_open(int ret)
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_OPEN, 1);
     
     __u32 key = 0;
+    __u32 tgid = 0;
     if (netdata_vfs_not_update_apps())
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->open_call, 1) ;
 
@@ -341,10 +348,11 @@ static __always_inline int netdata_common_vfs_create(int ret)
     libnetdata_update_global(&tbl_vfs_stats, NETDATA_KEY_CALLS_VFS_CREATE, 1);
 
     __u32 key = 0;
+    __u32 tgid = 0;
     if (netdata_vfs_not_update_apps())
         return 0;
 
-    fill = netdata_get_pid_structure(&key, &vfs_ctrl, &tbl_vfs_pid);
+    fill = netdata_get_pid_structure(&key, &tgid, &vfs_ctrl, &tbl_vfs_pid);
     if (fill) {
         libnetdata_update_u32(&fill->create_call, 1) ;
 

--- a/src/vfs.bpf.c
+++ b/src/vfs.bpf.c
@@ -41,6 +41,7 @@ struct {
 static __always_inline void netdata_fill_common_vfs_data(struct netdata_vfs_stat_t *data)
 {
     data->ct = bpf_ktime_get_ns();
+    libnetdata_update_uid_gid(&data.uid, &data.gid);
     bpf_get_current_comm(&data->name, TASK_COMM_LEN);
 }
 

--- a/src/vfs.bpf.c
+++ b/src/vfs.bpf.c
@@ -41,7 +41,7 @@ struct {
 static __always_inline void netdata_fill_common_vfs_data(struct netdata_vfs_stat_t *data)
 {
     data->ct = bpf_ktime_get_ns();
-    libnetdata_update_uid_gid(&data.uid, &data.gid);
+    libnetdata_update_uid_gid(&data->uid, &data->gid);
     bpf_get_current_comm(&data->name, TASK_COMM_LEN);
 }
 


### PR DESCRIPTION
##### Summary
This PR is updating some CO-RE algorithms used during to do integration between apps/cgroup and eBPF.
##### Test Plan
1. Clone this branch
2. Run the following commands:
```sh
# git submodule update --init --recursive
# make clean; make
# cd src/tests
# sh run_tests.sh
```
3. Verify that you do not have any `libbpf` error inside `error.log`.

##### Additional information

| Linux Distribution |   Environment  |Kernel Version |    Error    | Success |
|--------------------|----------------|---------------|-------------|---------|
| Slackware current  | Bare metal  | 6.1.55      |[error.log](https://github.com/netdata/ebpf-co-re/files/12836168/error.log) |[success.log](https://github.com/netdata/ebpf-co-re/files/12836169/success.log) |
|Arch Linux | libvirt | 6.5.5-arch1-1 | [error.log](https://github.com/netdata/ebpf-co-re/files/12838567/error.log) | [success.log](https://github.com/netdata/ebpf-co-re/files/12838568/success.log) | 
|Ubuntu 22.04 | libvirt | 5.15.0-76-generic | [error.log](https://github.com/netdata/ebpf-co-re/files/12841060/error.log) | [success.log](https://github.com/netdata/ebpf-co-re/files/12841061/success.log) | 
|Alma 9 | libvirt | 5.14.0-284.30.1.el9_2.x86_64| [error.log](https://github.com/netdata/ebpf-co-re/files/12841823/error.log) | [success.log](https://github.com/netdata/ebpf-co-re/files/12841824/success.log) | 
|Debian 11 | libvirt | 5.10.0-26-amd64 |[error.log](https://github.com/netdata/ebpf-co-re/files/12839528/error.log) | [success.log](https://github.com/netdata/ebpf-co-re/files/12839529/success.log) | 
|Alma 8 | Libvirt | 4.18.0-477.27.2.el8_8.x86_64 | [error.log](https://github.com/netdata/ebpf-co-re/files/12839018/error.log) | [success.log](https://github.com/netdata/ebpf-co-re/files/12839019/success.log) | 
