### PR TITLE
Upgrade versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         kernel_version:
-          - '6.1.26'
+          - '6.6.17'
         libc:
           - glibc
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         kernel_version:
-          - '6.1.26'
+          - '6.6.17'
         libc:
           - glibc
     runs-on: ubuntu-latest

--- a/Dockerfile.glibc.core
+++ b/Dockerfile.glibc.core
@@ -13,7 +13,7 @@ RUN apt-get update && \
     apt-get install -y build-essential autoconf automake coreutils pkg-config \
                        bc libelf-dev libssl-dev clang-tools-16 libclang-16-dev \
                        llvm-16 rsync bison flex tar xz-utils wget libbfd-dev \
-                       libcap-dev bpftool linux-tools-generic
+                       libcap-dev bpftool linux-tools-azure
 
 # hadolint ignore=DL3059
 RUN ln -s /usr/bin/clang-16 /usr/bin/clang && \

--- a/Dockerfile.glibc.core
+++ b/Dockerfile.glibc.core
@@ -3,7 +3,7 @@ FROM ubuntu:23.04 AS build
 ARG ARCH=x86
 ENV ARCH=$ARCH
 
-ARG LOCAL_KERNEL_VERSION=6.1.26
+ARG LOCAL_KERNEL_VERSION=6.6.17
 
 ENV _LIBC=glibc
 
@@ -13,11 +13,19 @@ RUN apt-get update && \
     apt-get install -y build-essential autoconf automake coreutils pkg-config \
                        bc libelf-dev libssl-dev clang-tools-16 libclang-16-dev \
                        llvm-16 rsync bison flex tar xz-utils wget libbfd-dev \
-                       libcap-dev bpftool linux-tools-azure
+                       libcap-dev
 
 # hadolint ignore=DL3059
 RUN ln -s /usr/bin/clang-16 /usr/bin/clang && \
     ln -s /usr/bin/llvm-strip-16 /usr/bin/llvm-strip
+
+# hadolint ignore=DL3003,SC3009,DL4006,SC2046
+RUN mkdir -p /usr/src && \
+    cd /usr/src && \
+    wget -q https://cdn.kernel.org/pub/linux/kernel/v$(echo "$LOCAL_KERNEL_VERSION" | cut -f 1 -d '.').x/linux-${LOCAL_KERNEL_VERSION}.tar.xz && \
+    tar -xf linux-${LOCAL_KERNEL_VERSION}.tar.xz && \
+    make -C linux-${LOCAL_KERNEL_VERSION}/tools/bpf/bpftool/ && \
+    cp linux-${LOCAL_KERNEL_VERSION}/tools/bpf/bpftool/bpftool /usr/bin/
 
 WORKDIR /ebpf-co-re
 

--- a/Dockerfile.glibc.core
+++ b/Dockerfile.glibc.core
@@ -11,21 +11,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 # hadolint ignore=DL3018,DL3015,DL3008,DL3009
 RUN apt-get update && \
     apt-get install -y build-essential autoconf automake coreutils pkg-config \
-                       bc libelf-dev libssl-dev clang-tools-15 libclang-15-dev \
-                       llvm-15 rsync bison flex tar xz-utils wget libbfd-dev \
-                       libcap-dev
+                       bc libelf-dev libssl-dev clang-tools-16 libclang-16-dev \
+                       llvm-16 rsync bison flex tar xz-utils wget libbfd-dev \
+                       libcap-dev bpftool linux-tools-generic
 
 # hadolint ignore=DL3059
-RUN ln -s /usr/bin/clang-15 /usr/bin/clang && \
-    ln -s /usr/bin/llvm-strip-15 /usr/bin/llvm-strip
-
-# hadolint ignore=DL3003,SC3009,DL4006,SC2046
-RUN mkdir -p /usr/src && \
-    cd /usr/src && \
-    wget -q https://cdn.kernel.org/pub/linux/kernel/v$(echo "$LOCAL_KERNEL_VERSION" | cut -f 1 -d '.').x/linux-${LOCAL_KERNEL_VERSION}.tar.xz && \
-    tar -xf linux-${LOCAL_KERNEL_VERSION}.tar.xz && \
-    make -C linux-${LOCAL_KERNEL_VERSION}/tools/bpf/bpftool/ && \
-    cp linux-${LOCAL_KERNEL_VERSION}/tools/bpf/bpftool/bpftool /usr/bin/
+RUN ln -s /usr/bin/clang-16 /usr/bin/clang && \
+    ln -s /usr/bin/llvm-strip-16 /usr/bin/llvm-strip
 
 WORKDIR /ebpf-co-re
 


### PR DESCRIPTION
##### Summary
It was observed that when compiled on kernels newer than 6.5, we are not collecting properly data for network viewer. We are upgrading clang and bpftool to address the issue.

##### Test Plan
1. Clone this branch
2. Run the following commands:
```sh
# git submodule update --init --recursive
# make clean; make
# cd src/tests
# sh run_tests.sh
```
3. Verify that you do not have any `libbpf` error inside `error.log`.

##### Additional information

| Linux Distribution |   Environment  |Kernel Version |    Error    | Success |
|--------------------|----------------|---------------|-------------|---------|
| LINUX DISTRIBUTION  | Bare metal/VM  | uname -r      |             |         |
