### PR TITLE
Discard necessity to read `/proc/

### DIFF
--- a/src/networkviewer.bpf.c
+++ b/src/networkviewer.bpf.c
@@ -57,16 +57,12 @@ static __always_inline __u16 set_nv_idx_value(netdata_nv_idx_t *nvi, struct sock
         BPF_CORE_READ_INTO(&nvi->saddr.ipv4, is, inet_saddr );
         BPF_CORE_READ_INTO(&nvi->daddr.ipv4, is, sk.__sk_common.skc_daddr );
         if (nvi->saddr.ipv4 == 0 || nvi->daddr.ipv4 == 0) // Zero
-            return AF_UNSPEC;
+            return AF_INET;
     }
     // Check necessary according https://elixir.bootlin.com/linux/v5.6.14/source/include/net/sock.h#L199
     else if ( family == AF_INET6 ) {
-        BPF_CORE_READ_INTO(&nvi->saddr.ipv6.addr8, is, sk.__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8 );
-        BPF_CORE_READ_INTO(&nvi->daddr.ipv6.addr8, is, sk.__sk_common.skc_v6_daddr.in6_u.u6_addr8 );
-
-        if (((nvi->saddr.ipv6.addr64[0] == 0) && (nvi->saddr.ipv6.addr64[1] == 0)) ||
-            ((nvi->daddr.ipv6.addr64[0] == 0) && (nvi->daddr.ipv6.addr64[1] == 0))) // Zero addr
-            return AF_UNSPEC;
+        BPF_CORE_READ_INTO(&nvi->saddr.ipv6.in6_u.u6_addr8, is, sk.__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8 );
+        BPF_CORE_READ_INTO(&nvi->daddr.ipv6.in6_u.u6_addr8, is, sk.__sk_common.skc_v6_daddr.in6_u.u6_addr8 );
     }
     else {
         return AF_UNSPEC;

--- a/src/networkviewer.c
+++ b/src/networkviewer.c
@@ -60,8 +60,14 @@ static int ebpf_attach_probes(struct networkviewer_bpf *obj)
         return -1;
 
     obj->links.netdata_nv_tcp_cleanup_rbuf_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_nv_tcp_cleanup_rbuf_kprobe,
-                                                                            false, function_list[NETDATA_FCNT_CLEANUP_RBUF]);
+                                                                            false, function_list[NETDATA_FCNT_TCP_CLOSE]);
     ret = libbpf_get_error(obj->links.netdata_nv_tcp_cleanup_rbuf_kprobe);
+    if (ret)
+        return -1;
+
+    obj->links.netdata_nv_tcp_close_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_nv_tcp_close_kprobe,
+                                                                            false, function_list[NETDATA_FCNT_CLEANUP_RBUF]);
+    ret = libbpf_get_error(obj->links.netdata_nv_tcp_close_kprobe);
     if (ret)
         return -1;
 
@@ -99,6 +105,7 @@ static void ebpf_disable_probes(struct networkviewer_bpf *obj)
     bpf_program__set_autoload(obj->progs.netdata_nv_tcp_v6_connect_kprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_nv_tcp_retransmit_skb_kprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_nv_tcp_cleanup_rbuf_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_nv_tcp_close_kprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_nv_udp_recvmsg_kprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_nv_tcp_sendmsg_kprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_nv_udp_sendmsg_kprobe, false);
@@ -112,6 +119,7 @@ static void ebpf_disable_trampoline(struct networkviewer_bpf *obj)
     bpf_program__set_autoload(obj->progs.netdata_nv_tcp_v6_connect_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_nv_tcp_retransmit_skb_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_nv_tcp_cleanup_rbuf_fentry, false);
+    bpf_program__set_autoload(obj->progs.netdata_nv_tcp_close_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_nv_udp_recvmsg_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_nv_tcp_sendmsg_fentry, false);
     bpf_program__set_autoload(obj->progs.netdata_nv_udp_sendmsg_fentry, false);
@@ -134,6 +142,9 @@ static void ebpf_set_trampoline_target(struct networkviewer_bpf *obj)
 
     bpf_program__set_attach_target(obj->progs.netdata_nv_tcp_cleanup_rbuf_fentry, 0,
                                    function_list[NETDATA_FCNT_CLEANUP_RBUF]);
+
+    bpf_program__set_attach_target(obj->progs.netdata_nv_tcp_close_fentry, 0,
+                                   function_list[NETDATA_FCNT_TCP_CLOSE]);
 
     bpf_program__set_attach_target(obj->progs.netdata_nv_udp_recvmsg_fentry, 0,
                                    function_list[NETDATA_FCNT_UDP_RECEVMSG]);


### PR DESCRIPTION
##### Summary
Sync algorithms and discard necessity to read proc files.

##### Test Plan
1. Clone this branch
2. Run the following commands:
```sh
# git submodule update --init --recursive
# make clean; make
# cd src/tests
# sh run_tests.sh
```
3. Verify that you do not have any `libbpf` error inside `error.log`.

##### Additional information

| Linux Distribution |   Environment  |Kernel Version |    Error    | Success |
|--------------------|----------------|---------------|-------------|---------|
| Slackware current  | Bare metal  | 6.6.20      | [error.log](https://github.com/netdata/ebpf-co-re/files/14476144/error.log) | success.log](https://github.com/netdata/ebpf-co-re/files/14476145/success.log) | 
