### PR TITLE
Fix SWAP

### DIFF
--- a/src/swap.bpf.c
+++ b/src/swap.bpf.c
@@ -130,6 +130,12 @@ int BPF_KPROBE(netdata_swap_writepage_probe)
     return common_writepage();
 }
 
+SEC("kprobe/__swap_writepage")
+int BPF_KPROBE(netdata___swap_writepage_probe)
+{
+    return common_writepage();
+}
+
 /***********************************************************************************
  *
  *                            SWAP SECTION(trampoline)
@@ -150,6 +156,12 @@ int BPF_PROG(netdata_swap_readpage_fentry)
 
 SEC("fentry/swap_writepage")
 int BPF_PROG(netdata_swap_writepage_fentry)
+{
+    return common_writepage();
+}
+
+SEC("fentry/__swap_writepage")
+int BPF_PROG(netdata___swap_writepage_fentry)
 {
     return common_writepage();
 }

--- a/src/swap.c
+++ b/src/swap.c
@@ -130,9 +130,9 @@ static int attach_kprobe(struct swap_bpf *obj)
                                                                              false, function_list[NETDATA_KEY_SWAP_WRITEPAGE_CALL]);
         ret = libbpf_get_error(obj->links.netdata_swap_writepage_probe);
     } else {
-        obj->links.netdata___swap_writepage_fentry = bpf_program__attach_kprobe(obj->progs.netdata___swap_writepage_fentry,
+        obj->links.netdata___swap_writepage_probe = bpf_program__attach_kprobe(obj->progs.netdata___swap_writepage_probe,
                                                                                 false, function_list[NETDATA_KEY_SWAP_WRITEPAGE_CALL]);
-        ret = libbpf_get_error(obj->links.netdata___swap_writepage_fentry);
+        ret = libbpf_get_error(obj->links.netdata___swap_writepage_probe);
     }
 
     if (ret)


### PR DESCRIPTION
##### Summary
Kernel 6.16.0 brought changes for swap monitoring removing a function. This PR brings necessary changes to support this.

##### Test Plan
1. Clone this branch
2. Run the following commands:
```sh
# git submodule update --init --recursive
# make clean; make
# cd src/tests
# sh run_tests.sh
```
3. Verify that you do not have any `libbpf` error inside `error.log`.

##### Additional information

| Linux Distribution |   Environment  |Kernel Version |    Error    | Success |
|--------------------|----------------|---------------|-------------|---------|
| Slackware  | Bare metal  | 6.12.43      | [error.log](https://github.com/user-attachments/files/21957796/error.log) | [success.log](https://github.com/user-attachments/files/21957797/success.log) |
| Debian 11 | VM | 5.10.237-1 | [error.log](https://github.com/user-attachments/files/21958037/error.log) | [success.log](https://github.com/user-attachments/files/21958038/success.log) | 
| Arch Linux | VM | 6.16.2-arch1-1 | [error.log](https://github.com/user-attachments/files/21958784/error.log) | [success.log](https://github.com/user-attachments/files/21958785/success.log)| 